### PR TITLE
Update setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,24 @@ conda activate evoagentx
 
 # Install the package
 pip install -r requirements.txt
-# OR install in development mode
+# Or install in development mode
 pip install -e .
 ```
 </details>
+
+## Setup
+
+Before running any scripts or examples, install the project dependencies:
+
+```bash
+pip install -e .[dev]
+# or install from requirements
+pip install -r requirements.txt
+```
+
+This installs optional packages such as `python-dotenv`. The
+`run_evoagentx.py` script relies on `load_dotenv()` to read your `.env`
+file, so these dependencies must be installed first.
 
 ## LLM Configuration
 


### PR DESCRIPTION
## Summary
- add a new **Setup** section in the README recommending `pip install -e .[dev]` or `pip install -r requirements.txt`
- explain that this installs `python-dotenv` which enables `load_dotenv()` in `run_evoagentx.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for numpy, yaml, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684e12b4711483268425144fb3dfc67b