### PR TITLE
Add FastAPI backend and React frontend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
-OPENAI_API_KEY=<your-openai-api-key>
-ANTHROPIC_API_KEY=<your-anthropic-api-key>
+# Copy to .env and set your OpenAI API key
+OPENAI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -352,6 +352,27 @@ We appreciate your interest in contributing to our open-source initiative. We pr
 [![Star History Chart](https://api.star-history.com/svg?repos=EvoAgentX/EvoAgentX&type=Date)](https://www.star-history.com/#EvoAgentX/EvoAgentX&Date)
 
 
+## Quick Start (Full Stack)
+
+1. Copy `.env.example` to `.env` and add your `OPENAI_API_KEY`.
+2. Create a virtual environment and install backend dependencies:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r server/requirements.txt
+uvicorn server.main:app --reload
+```
+
+3. For the React frontend:
+
+```bash
+cd client
+pnpm install
+pnpm dev
+```
+
+
 ## 📚 Acknowledgements 
 This project builds upon several outstanding open-source projects: [AFlow](https://github.com/FoundationAgents/MetaGPT/tree/main/metagpt/ext/aflow), [TextGrad](https://github.com/zou-group/textgrad), [DSPy](https://github.com/stanfordnlp/dspy), [LiveCodeBench](https://github.com/LiveCodeBench/LiveCodeBench), and more. We would like to thank the developers and maintainers of these frameworks for their valuable contributions to the open-source community.
 

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>EvoAgentX</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,0 +1,34 @@
+import { useState } from 'react';
+
+function App() {
+  const [goal, setGoal] = useState('');
+  const [output, setOutput] = useState('');
+
+  const run = async () => {
+    const res = await fetch('http://localhost:8000/run', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ goal })
+    });
+    const data = await res.json();
+    setOutput(data.output);
+  };
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h1>EvoAgentX</h1>
+      <textarea
+        value={goal}
+        onChange={(e) => setGoal(e.target.value)}
+        placeholder="Enter goal"
+        rows={4}
+        cols={60}
+      />
+      <br />
+      <button onClick={run}>Run</button>
+      <pre>{output}</pre>
+    </div>
+  );
+}
+
+export default App;

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+  },
+});

--- a/evoagentx/core/runner.py
+++ b/evoagentx/core/runner.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import os
+from dotenv import load_dotenv
+from evoagentx.models import OpenAILLMConfig, OpenAILLM
+from evoagentx.workflow import WorkFlowGenerator, WorkFlowGraph, WorkFlow
+from evoagentx.agents import AgentManager
+
+
+def run_workflow(goal: str) -> str:
+    """Generate and execute a workflow for a given goal and return output."""
+    load_dotenv()
+    openai_key = os.getenv("OPENAI_API_KEY")
+
+    llm_config = OpenAILLMConfig(
+        model="gpt-4o-mini",
+        openai_key=openai_key,
+        stream=True,
+        output_response=True,
+        max_tokens=16000,
+    )
+    llm = OpenAILLM(config=llm_config)
+
+    wf_generator = WorkFlowGenerator(llm=llm)
+    workflow_graph: WorkFlowGraph = wf_generator.generate_workflow(goal=goal)
+
+    agent_manager = AgentManager()
+    agent_manager.add_agents_from_workflow(workflow_graph, llm_config=llm_config)
+
+    workflow = WorkFlow(graph=workflow_graph, agent_manager=agent_manager, llm=llm)
+    output = workflow.execute()
+    return output

--- a/run_evoagentx.py
+++ b/run_evoagentx.py
@@ -1,35 +1,10 @@
-import os
-from dotenv import load_dotenv
-from evoagentx.models import OpenAILLMConfig, OpenAILLM
-from evoagentx.workflow import WorkFlowGenerator, WorkFlowGraph, WorkFlow
-from evoagentx.agents import AgentManager
+from evoagentx.core.runner import run_workflow
 
 
 def main():
     """Generate and execute a workflow based on a user provided goal."""
-    load_dotenv()
     goal = input("Enter the goal for EvoAgentX: ").strip()
-    openai_key = os.getenv("OPENAI_API_KEY")
-
-    llm_config = OpenAILLMConfig(
-        model="gpt-4o-mini",
-        openai_key=openai_key,
-        stream=True,
-        output_response=True,
-        max_tokens=16000,
-    )
-    llm = OpenAILLM(config=llm_config)
-
-    wf_generator = WorkFlowGenerator(llm=llm)
-    workflow_graph: WorkFlowGraph = wf_generator.generate_workflow(goal=goal)
-
-    workflow_graph.display()
-
-    agent_manager = AgentManager()
-    agent_manager.add_agents_from_workflow(workflow_graph, llm_config=llm_config)
-
-    workflow = WorkFlow(graph=workflow_graph, agent_manager=agent_manager, llm=llm)
-    output = workflow.execute()
+    output = run_workflow(goal)
     print(output)
 
 

--- a/server/api/run.py
+++ b/server/api/run.py
@@ -1,0 +1,12 @@
+from fastapi import APIRouter
+
+from ..core.agent_runner import run_goal
+from ..models.schemas import RunRequest, RunResponse
+
+router = APIRouter()
+
+
+@router.post("/run", response_model=RunResponse)
+async def run(request: RunRequest) -> RunResponse:
+    output = run_goal(request.goal)
+    return RunResponse(goal=request.goal, output=output)

--- a/server/core/agent_runner.py
+++ b/server/core/agent_runner.py
@@ -1,0 +1,5 @@
+from evoagentx.core.runner import run_workflow
+
+
+def run_goal(goal: str) -> str:
+    return run_workflow(goal)

--- a/server/main.py
+++ b/server/main.py
@@ -1,0 +1,20 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from .api.run import router as run_router
+
+app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:5173"],
+    allow_credentials=True,
+    allow_methods=["*"] ,
+    allow_headers=["*"] ,
+)
+
+app.include_router(run_router)
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run("server.main:app", host="0.0.0.0", port=8000, reload=True)

--- a/server/models/schemas.py
+++ b/server/models/schemas.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel
+
+
+class RunRequest(BaseModel):
+    goal: str
+
+
+class RunResponse(BaseModel):
+    goal: str
+    output: str

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn[standard]
+python-dotenv


### PR DESCRIPTION
## Summary
- refactor CLI to use new `run_workflow` function
- implement fastapi backend under `server/`
- add simple React+Vite client
- provide `.env.example`
- update README with full-stack quick start guide

## Testing
- `pip install -e .[dev]`
- `pip install bs4 textgrad googlesearch-python wikipedia mcp`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e254981488326a401f47c1e13d3ed