### PR TITLE
Add loading state with spinner and error display

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,17 +1,29 @@
 import { useState } from 'react';
+import Loader from './components/Loader';
 
 function App() {
   const [goal, setGoal] = useState('');
   const [output, setOutput] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
 
   const run = async () => {
-    const res = await fetch('http://localhost:8000/run', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ goal })
-    });
-    const data = await res.json();
-    setOutput(data.output);
+    setLoading(true);
+    setError('');
+    try {
+      const res = await fetch('http://localhost:8000/run', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ goal })
+      });
+      if (!res.ok) throw new Error(`Status ${res.status}`);
+      const data = await res.json();
+      setOutput(data.output);
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
@@ -26,6 +38,8 @@ function App() {
       />
       <br />
       <button onClick={run}>Run</button>
+      {loading && <Loader />}
+      {error && <p className="text-red-600 mt-2">{error}</p>}
       <pre>{output}</pre>
     </div>
   );

--- a/client/src/components/Loader.tsx
+++ b/client/src/components/Loader.tsx
@@ -1,0 +1,5 @@
+export default function Loader() {
+  return (
+    <div className="animate-spin rounded-full h-6 w-6 border-2 border-t-transparent mx-auto" />
+  );
+}


### PR DESCRIPTION
## Summary
- show a spinner while running goals
- display fetch errors to the user

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: numpy, yaml)*

------
https://chatgpt.com/codex/tasks/task_e_684e347c72588326b802ee003be67590