### PR TITLE
Refactor React dashboard components

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,50 +1,5 @@
-import { useState } from 'react';
-import OutputPanel from './components/OutputPanel';
-import Loader from './components/Loader';
+import Dashboard from './Dashboard';
 
-function App() {
-  const [goal, setGoal] = useState('');
-  const [output, setOutput] = useState('');
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState('');
-
-  const run = async () => {
-    setLoading(true);
-    setError('');
-    try {
-      const res = await fetch('http://localhost:8000/run', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ goal })
-      });
-      if (!res.ok) throw new Error(`Status ${res.status}`);
-      const data = await res.json();
-      setOutput(data.output);
-    } catch (err: any) {
-      setError(err.message);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  return (
-    <div style={{ padding: '1rem' }}>
-      <h1>EvoAgentX</h1>
-      <textarea
-        value={goal}
-        onChange={(e) => setGoal(e.target.value)}
-        placeholder="Enter goal"
-        rows={4}
-        cols={60}
-      />
-      <br />
-      <button onClick={run}>Run</button>
-      <OutputPanel output={output} />
-      {loading && <Loader />}
-      {error && <p className="text-red-600 mt-2">{error}</p>}
-      <pre>{output}</pre>
-    </div>
-  );
+export default function App() {
+  return <Dashboard />;
 }
-
-export default App;

--- a/client/src/Dashboard.tsx
+++ b/client/src/Dashboard.tsx
@@ -1,0 +1,40 @@
+import { useState } from 'react';
+import GoalInput from './components/GoalInput';
+import OutputPanel from './components/OutputPanel';
+import Loader from './components/Loader';
+
+export default function Dashboard() {
+  const [output, setOutput] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const run = async (goal: string) => {
+    setLoading(true);
+    setError('');
+    try {
+      const res = await fetch('http://localhost:8000/run', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ goal })
+      });
+      if (!res.ok) throw new Error(`Status ${res.status}`);
+      const data = await res.json();
+      setOutput(data.output);
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h1>EvoAgentX</h1>
+      <GoalInput onRun={run} loading={loading} />
+      <OutputPanel output={output} />
+      {loading && <Loader />}
+      {error && <p className="text-red-600 mt-2">{error}</p>}
+      <pre>{output}</pre>
+    </div>
+  );
+}

--- a/client/src/components/GoalInput.tsx
+++ b/client/src/components/GoalInput.tsx
@@ -1,0 +1,27 @@
+import { useState } from 'react';
+
+interface Props {
+  onRun: (goal: string) => void;
+  loading: boolean;
+}
+export default function GoalInput({ onRun, loading }: Props) {
+  const [goal, setGoal] = useState('');
+  return (
+    <>
+      <textarea
+        className="w-full p-3 rounded border"
+        rows={3}
+        value={goal}
+        onChange={e => setGoal(e.target.value)}
+        placeholder="Enter goal"
+      />
+      <button
+        onClick={() => onRun(goal)}
+        disabled={!goal || loading}
+        className="mt-2 px-4 py-2 rounded bg-blue-600 text-white disabled:opacity-40"
+      >
+        {loading ? 'Running…' : 'Run'}
+      </button>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable GoalInput component containing textarea + button
- move state and fetch logic to new Dashboard component
- simplify App.tsx to only render Dashboard

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e3828fc508326943c09d81687896d