### PR TITLE
Fix test module collection

### DIFF
--- a/evoagentx/benchmark/lcb_utils/output_prediction.py
+++ b/evoagentx/benchmark/lcb_utils/output_prediction.py
@@ -14,7 +14,7 @@ class Test:
 
 
 @dataclass
-class TestOutputPredictionProblem:
+class OutputPredictionProblem:
     question_title: str
     question_content: str
     question_id: str
@@ -59,9 +59,9 @@ class TestOutputPredictionProblem:
         }
 
 
-def load_test_prediction_dataset(release_version="release_v1", cache_dir: str = None,) -> list[TestOutputPredictionProblem]:
+def load_test_prediction_dataset(release_version="release_v1", cache_dir: str = None,) -> list[OutputPredictionProblem]:
     dataset = load_dataset("livecodebench/test_generation", split="test", trust_remote_code=True, cache_dir=cache_dir)  # type: ignore
-    dataset = [TestOutputPredictionProblem(**d) for d in dataset]
+    dataset = [OutputPredictionProblem(**d) for d in dataset]
     # print(f"Loaded {len(dataset)} prediction problems")
     return dataset
 

--- a/evoagentx/benchmark/livecodebench.py
+++ b/evoagentx/benchmark/livecodebench.py
@@ -8,8 +8,8 @@ from .lcb_utils.code_generation import (
     CodeGenerationProblem, 
     load_code_generation_dataset
 )
-from .lcb_utils.test_output_prediction import (
-    TestOutputPredictionProblem, 
+from .lcb_utils.output_prediction import (
+    OutputPredictionProblem,
     load_test_prediction_dataset
 )
 from .lcb_utils.code_execution import (
@@ -94,7 +94,7 @@ class LiveCodeBench(CodingBenchmark):
             )
         elif self.scenario == "test_output_prediction":
             logger.info(f"Loading test output prediction dataset from {self.path}.")
-            data: List[TestOutputPredictionProblem] = load_test_prediction_dataset(cache_dir=self.path)
+            data: List[OutputPredictionProblem] = load_test_prediction_dataset(cache_dir=self.path)
         elif self.scenario == "code_execution":
             logger.info(f"Loading code execution dataset from {self.path}.")
             data: List[CodeExecutionProblem] = load_code_execution_dataset(cache_dir=self.path)
@@ -103,10 +103,10 @@ class LiveCodeBench(CodingBenchmark):
 
         return data 
     
-    def _get_id(self, example: Union[CodeGenerationProblem, TestOutputPredictionProblem]) -> str:
+    def _get_id(self, example: Union[CodeGenerationProblem, OutputPredictionProblem]) -> str:
         return example.question_id  
     
-    def _get_label(self, example: Union[CodeGenerationProblem, TestOutputPredictionProblem]) -> dict:
+    def _get_label(self, example: Union[CodeGenerationProblem, OutputPredictionProblem]) -> dict:
         return example.get_evaluation_sample()
     
     def evaluate(self, prediction: Any, label: Any) -> dict:

--- a/tests/src/benchmark/test_livecodebench.py
+++ b/tests/src/benchmark/test_livecodebench.py
@@ -6,7 +6,7 @@ import tempfile
 from datasets import load_from_disk 
 from evoagentx.benchmark.livecodebench import LiveCodeBench
 from evoagentx.benchmark.lcb_utils.code_generation import CodeGenerationProblem
-from evoagentx.benchmark.lcb_utils.test_output_prediction import TestOutputPredictionProblem
+from evoagentx.benchmark.lcb_utils.output_prediction import OutputPredictionProblem
 from evoagentx.benchmark.lcb_utils.code_execution import CodeExecutionProblem
 from tests.src.benchmark.lcb_solutions import (
     codegen_solution, codegen_solution2, codegen_solution3,
@@ -49,7 +49,7 @@ class TestLiveCodeBench(unittest.TestCase):
 
     @patch("evoagentx.benchmark.livecodebench.load_test_prediction_dataset")
     def test_test_output_prediction(self, mock_load_dataset):
-        mock_load_dataset.return_value = [TestOutputPredictionProblem(**p) for p in self.test_output_prediction_samples]
+        mock_load_dataset.return_value = [OutputPredictionProblem(**p) for p in self.test_output_prediction_samples]
 
         benchmark = LiveCodeBench(scenario="test_output_prediction")
         test_data = benchmark.get_test_data()


### PR DESCRIPTION
## Summary
- rename `test_output_prediction.py` to `output_prediction.py`
- update imports and rename dataclass `OutputPredictionProblem`

## Testing
- `pip install -e .[dev]`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'textgrad')*

------
https://chatgpt.com/codex/tasks/task_e_684e3d269d3483268d5c4cc151d7f799