### PR TITLE
Implement simple planner with events API

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Routes, Route, NavLink } from 'react-router-dom';
 import Dashboard from './pages/Dashboard';
+import Planner from './pages/Planner';
 
 export default function App() {
   return (
@@ -8,13 +9,14 @@ export default function App() {
         {/* sidebar */}
         <nav className="w-52 border-r p-4 space-y-2">
           <NavLink to="/" className="block">Agent Hub</NavLink>
-          {/* future links */}
+          <NavLink to="/planner" className="block">Planner</NavLink>
         </nav>
 
         {/* main */}
         <div className="flex-1 p-8 overflow-y-auto">
           <Routes>
             <Route path="/" element={<Dashboard />} />
+            <Route path="/planner" element={<Planner />} />
             {/* <Route path="/history" element={<History />} /> */}
           </Routes>
         </div>

--- a/client/src/pages/Planner.tsx
+++ b/client/src/pages/Planner.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useState, FormEvent } from 'react';
+
+interface EventItem {
+  id: number;
+  title: string;
+  start: string;
+  end: string;
+}
+
+export default function Planner() {
+  const [events, setEvents] = useState<EventItem[]>([]);
+  const [title, setTitle] = useState('');
+  const [start, setStart] = useState('');
+  const [end, setEnd] = useState('');
+  const [editing, setEditing] = useState<EventItem | null>(null);
+
+  const loadEvents = async () => {
+    const res = await fetch('http://localhost:8000/events');
+    if (res.ok) {
+      const data = await res.json();
+      setEvents(data);
+    }
+  };
+
+  useEffect(() => { void loadEvents(); }, []);
+
+  const submit = async (e: FormEvent) => {
+    e.preventDefault();
+    const payload = { title, start, end };
+    if (editing) {
+      await fetch(`http://localhost:8000/events/${editing.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+    } else {
+      await fetch('http://localhost:8000/events', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+    }
+    setTitle('');
+    setStart('');
+    setEnd('');
+    setEditing(null);
+    void loadEvents();
+  };
+
+  const edit = (ev: EventItem) => {
+    setEditing(ev);
+    setTitle(ev.title);
+    setStart(ev.start);
+    setEnd(ev.end);
+  };
+
+  const remove = async (id: number) => {
+    await fetch(`http://localhost:8000/events/${id}`, { method: 'DELETE' });
+    void loadEvents();
+  };
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-bold">Today's Events</h2>
+      <form onSubmit={submit} className="space-x-2">
+        <input
+          className="border p-1 rounded"
+          placeholder="Title"
+          value={title}
+          onChange={e => setTitle(e.target.value)}
+        />
+        <input
+          className="border p-1 rounded"
+          placeholder="Start"
+          value={start}
+          onChange={e => setStart(e.target.value)}
+        />
+        <input
+          className="border p-1 rounded"
+          placeholder="End"
+          value={end}
+          onChange={e => setEnd(e.target.value)}
+        />
+        <button className="px-2 py-1 bg-blue-600 text-white rounded" type="submit">
+          {editing ? 'Update' : 'Add'}
+        </button>
+      </form>
+      <ul className="space-y-1">
+        {events.map(ev => (
+          <li key={ev.id} className="flex items-center space-x-2">
+            <span className="flex-1">
+              {ev.title} {ev.start} - {ev.end}
+            </span>
+            <button className="text-sm text-blue-600" onClick={() => edit(ev)}>Edit</button>
+            <button className="text-sm text-red-600" onClick={() => remove(ev.id)}>
+              Delete
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/server/api/events.py
+++ b/server/api/events.py
@@ -1,0 +1,37 @@
+from fastapi import APIRouter, HTTPException
+from server.models.schemas import Event, EventCreate
+
+router = APIRouter()
+
+_events: list[Event] = []
+_next_id = 1
+
+@router.get("/events", response_model=list[Event])
+def list_events():
+    return _events
+
+@router.post("/events", response_model=Event)
+def add_event(event: EventCreate):
+    global _next_id
+    new = Event(id=_next_id, **event.dict())
+    _events.append(new)
+    _next_id += 1
+    return new
+
+@router.put("/events/{event_id}", response_model=Event)
+def update_event(event_id: int, event: EventCreate):
+    for e in _events:
+        if e.id == event_id:
+            e.title = event.title
+            e.start = event.start
+            e.end = event.end
+            return e
+    raise HTTPException(status_code=404, detail="Event not found")
+
+@router.delete("/events/{event_id}")
+def delete_event(event_id: int):
+    for i, e in enumerate(_events):
+        if e.id == event_id:
+            _events.pop(i)
+            return {"ok": True}
+    raise HTTPException(status_code=404, detail="Event not found")

--- a/server/main.py
+++ b/server/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from .api.run import router as run_router
+from .api.events import router as events_router
 
 app = FastAPI()
 
@@ -14,6 +15,7 @@ app.add_middleware(
 )
 
 app.include_router(run_router)
+app.include_router(events_router)
 
 if __name__ == "__main__":
     import uvicorn

--- a/server/models/schemas.py
+++ b/server/models/schemas.py
@@ -8,3 +8,17 @@ class RunRequest(BaseModel):
 class RunResponse(BaseModel):
     goal: str
     output: str
+
+
+class EventBase(BaseModel):
+    title: str
+    start: str
+    end: str
+
+
+class EventCreate(EventBase):
+    pass
+
+
+class Event(EventBase):
+    id: int


### PR DESCRIPTION
## Summary
- build a server API to CRUD planner events
- expose planner UI with React and hook it into routing
- link planner page from sidebar

## Testing
- `pip install -e .[dev]` *(passes)*
- `pytest -q` *(fails: 2 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_684e516a2ef48326b7b612fd94657e12