### PR TITLE
Add missing GoalInput component

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -25,5 +25,3 @@ export default function App() {
 
   );
 }
-
-export default App;

--- a/client/src/components/GoalInput.tsx
+++ b/client/src/components/GoalInput.tsx
@@ -1,0 +1,34 @@
+import { useState, type FormEvent } from 'react';
+
+interface Props {
+  onRun: (goal: string) => void;
+  loading: boolean;
+}
+
+export default function GoalInput({ onRun, loading }: Props) {
+  const [goal, setGoal] = useState('');
+
+  const submit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!goal.trim()) return;
+    onRun(goal.trim());
+  };
+
+  return (
+    <form onSubmit={submit} className="flex space-x-2">
+      <input
+        className="flex-1 border p-2 rounded"
+        placeholder="Enter your goal"
+        value={goal}
+        onChange={e => setGoal(e.target.value)}
+      />
+      <button
+        className="px-4 py-2 bg-blue-600 text-white rounded"
+        type="submit"
+        disabled={loading}
+      >
+        Run
+      </button>
+    </form>
+  );
+}

--- a/client/src/components/OutputPanel.tsx
+++ b/client/src/components/OutputPanel.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import type { FC } from 'react';
 
 interface Props { output: string }
 const OutputPanel: FC<Props> = ({ output }) => (

--- a/client/src/pages/Planner.tsx
+++ b/client/src/pages/Planner.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState, FormEvent } from 'react';
+import { useEffect, useState } from 'react';
+import type { FormEvent } from 'react';
 
 interface EventItem {
   id: number;


### PR DESCRIPTION
## Summary
- implement a GoalInput component used on the dashboard
- fix type-only imports and remove duplicate export
- adjust Planner imports for `FormEvent`
- ensure TS build succeeds

## Testing
- `pnpm build`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e5422f6ac8326bd2a3c8944e4f890