### PR TITLE
Add calendar API routes

### DIFF
--- a/server/api/__init__.py
+++ b/server/api/__init__.py
@@ -1,0 +1,5 @@
+from .calendar import calendar_router
+from .events import events_router
+from .run import router as run_router
+
+__all__ = ["calendar_router", "events_router", "run_router"]

--- a/server/api/calendar.py
+++ b/server/api/calendar.py
@@ -1,0 +1,29 @@
+from fastapi import APIRouter, HTTPException
+
+from server.models.schemas import Event, EventCreate
+from .calendar_store import calendar_store
+
+calendar_router = APIRouter(prefix="/calendar")
+
+@calendar_router.get("/today", response_model=list[Event])
+def get_today():
+    return calendar_store.list_today()
+
+@calendar_router.post("/event", response_model=Event)
+def create_event(event: EventCreate):
+    return calendar_store.add(event)
+
+@calendar_router.put("/event/{event_id}", response_model=Event)
+def update_event(event_id: int, event: EventCreate):
+    try:
+        return calendar_store.update(event_id, event)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="Event not found")
+
+@calendar_router.delete("/event/{event_id}")
+def delete_event(event_id: int):
+    try:
+        calendar_store.delete(event_id)
+        return {"ok": True}
+    except KeyError:
+        raise HTTPException(status_code=404, detail="Event not found")

--- a/server/api/calendar_store.py
+++ b/server/api/calendar_store.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from datetime import date, datetime
+from typing import List
+
+from server.models.schemas import Event, EventCreate
+
+class CalendarStore:
+    def __init__(self, path: str | Path | None = None):
+        self.path = Path(path) if path else None
+        self._events: List[Event] = []
+        self._next_id = 1
+        if self.path and self.path.exists():
+            self._load()
+
+    def _load(self) -> None:
+        try:
+            data = json.loads(self.path.read_text())
+            self._events = [Event(**e) for e in data.get("events", [])]
+            if self._events:
+                self._next_id = max(e.id for e in self._events) + 1
+        except Exception:
+            self._events = []
+            self._next_id = 1
+
+    def _save(self) -> None:
+        if not self.path:
+            return
+        self.path.write_text(
+            json.dumps({"events": [e.dict() for e in self._events]}, indent=2)
+        )
+
+    def list_today(self) -> List[Event]:
+        today = date.today()
+        results = []
+        for e in self._events:
+            try:
+                event_date = datetime.fromisoformat(e.start).date()
+            except Exception:
+                continue
+            if event_date == today:
+                results.append(e)
+        return results
+
+    def add(self, event: EventCreate) -> Event:
+        new = Event(id=self._next_id, **event.dict())
+        self._events.append(new)
+        self._next_id += 1
+        self._save()
+        return new
+
+    def update(self, event_id: int, event: EventCreate) -> Event:
+        for e in self._events:
+            if e.id == event_id:
+                e.title = event.title
+                e.start = event.start
+                e.end = event.end
+                self._save()
+                return e
+        raise KeyError("Event not found")
+
+    def delete(self, event_id: int) -> None:
+        for i, e in enumerate(self._events):
+            if e.id == event_id:
+                self._events.pop(i)
+                self._save()
+                return
+        raise KeyError("Event not found")
+
+calendar_store = CalendarStore()

--- a/server/main.py
+++ b/server/main.py
@@ -3,6 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from .api.run import router as run_router
 from .api.events import events_router
+from .api.calendar import calendar_router
 
 app = FastAPI()
 
@@ -16,6 +17,7 @@ app.add_middleware(
 
 app.include_router(run_router)
 app.include_router(events_router)
+app.include_router(calendar_router)
 
 if __name__ == "__main__":
     import uvicorn


### PR DESCRIPTION
## Summary
- add in-memory calendar store
- add calendar API endpoints (today, create, update, delete)
- expose calendar router in main API app

## Testing
- `pip install -e .[dev]`
- `pytest -q` *(fails: 2 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684e5abe90a48326b34cb955125ebc15