### PR TITLE
Add calendar integration

### DIFF
--- a/docs/tutorial/tools.md
+++ b/docs/tutorial/tools.md
@@ -5,7 +5,8 @@ This tutorial walks you through using EvoAgentX's powerful tool ecosystem. Tools
 1. **Understanding the Tool Architecture**: Learn about the base Tool class and its functionality
 2. **Code Interpreters**: Execute Python code safely using Python and Docker interpreters
 3. **Search Tools**: Access information from the web using Wikipedia and Google search tools
-4. **MCP Tools**: Connect to external services using the Model Context Protocol
+4. **Calendar Tool**: Manage events and view today's schedule
+5. **MCP Tools**: Connect to external services using the Model Context Protocol
 
 By the end of this tutorial, you'll understand how to leverage these tools in your own agents and workflows.
 
@@ -452,7 +453,29 @@ for i, result in enumerate(results.get("results", [])):
 
 ---
 
-## 4. MCP Tools
+## 4. Calendar Tool
+
+EvoAgentX includes a lightweight `CalendarTool` for storing and retrieving daily events. Agents can read today's schedule and update it dynamically.
+
+### 4.1 Setup
+
+```python
+from evoagentx.tools.calendar import CalendarTool
+
+calendar = CalendarTool()
+today = calendar.get_today()
+```
+
+### 4.2 Available Methods
+
+- `get_today()` – list today's events
+- `add_event(title, start, end)` – create a new event
+- `remove_event(event_id)` – delete an event
+- `update_event(event_id, title, start, end)` – modify an event
+
+---
+
+## 5. MCP Tools
 
 **The Model Context Protocol (MCP) toolkit provides a standardized way to connect to external services through the MCP protocol. It enables agents to access specialized tools like job search services, data processing utilities, and other MCP-compatible APIs without requiring direct integration of each service.**
 
@@ -598,7 +621,8 @@ In this tutorial, we've explored the tool ecosystem in EvoAgentX:
 1. **Tool Architecture**: Understood the base Tool class and its standardized interface
 2. **Code Interpreters**: Learned how to execute Python code securely using both Python and Docker interpreters
 3. **Search Tools**: Discovered how to access web information using Wikipedia and Google search tools
-4. **MCP Tools**: Learned how to connect to external services using the Model Context Protocol
+4. **Calendar Tool**: Managed daily events through the built-in calendar
+5. **MCP Tools**: Learned how to connect to external services using the Model Context Protocol
 
 Tools in EvoAgentX extend your agents' capabilities by providing access to external resources and computation. By combining these tools with agents and workflows, you can build powerful AI systems that can retrieve information, perform calculations, and interact with the world.
 

--- a/evoagentx/tools/__init__.py
+++ b/evoagentx/tools/__init__.py
@@ -6,10 +6,11 @@ from .search_base import SearchBase
 from .search_google_f import SearchGoogleFree
 from .search_wiki import SearchWiki
 from .search_google import SearchGoogle
+from .calendar import CalendarTool
 from .mcp import MCPClient, MCPToolkit
 
 
 __all__ = ["Tool", "BaseInterpreter", "DockerInterpreter", 
            "PythonInterpreter", "SearchBase", "SearchGoogleFree", "SearchWiki", "SearchGoogle",
-           "MCPClient", "MCPToolkit"]
+           "CalendarTool", "MCPClient", "MCPToolkit"]
 

--- a/evoagentx/tools/calendar.py
+++ b/evoagentx/tools/calendar.py
@@ -1,0 +1,100 @@
+from typing import List, Callable, Dict, Any
+from pydantic import Field
+
+from .tool import Tool
+from server.models.schemas import EventCreate
+
+def _store():
+    from server.api.calendar_store import calendar_store
+    return calendar_store
+
+class CalendarTool(Tool):
+    """Simple tool for interacting with the built-in calendar store."""
+
+    name: str = "calendar"
+
+    def get_today(self) -> List[dict]:
+        """Return today's events as a list of dictionaries."""
+        store = _store()
+        return [e.dict() for e in store.list_today()]
+
+    def add_event(self, title: str, start: str, end: str) -> dict:
+        """Add an event to the calendar."""
+        store = _store()
+        event = EventCreate(title=title, start=start, end=end)
+        return store.add(event).dict()
+
+    def remove_event(self, event_id: int) -> dict:
+        """Remove an event from the calendar."""
+        store = _store()
+        store.delete(event_id)
+        return {"deleted": event_id}
+
+    def update_event(self, event_id: int, title: str, start: str, end: str) -> dict:
+        """Update an existing calendar event."""
+        store = _store()
+        event = EventCreate(title=title, start=start, end=end)
+        return store.update(event_id, event).dict()
+
+    def get_tools(self) -> List[Callable]:
+        return [self.get_today, self.add_event, self.remove_event, self.update_event]
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_today",
+                    "description": "Return today's calendar events.",
+                    "parameters": {"type": "object", "properties": {}, "required": []},
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "add_event",
+                    "description": "Add a calendar event.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "title": {"type": "string"},
+                            "start": {"type": "string"},
+                            "end": {"type": "string"},
+                        },
+                        "required": ["title", "start", "end"],
+                    },
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "remove_event",
+                    "description": "Remove a calendar event by id.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"event_id": {"type": "integer"}},
+                        "required": ["event_id"],
+                    },
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "update_event",
+                    "description": "Update an existing calendar event.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "event_id": {"type": "integer"},
+                            "title": {"type": "string"},
+                            "start": {"type": "string"},
+                            "end": {"type": "string"},
+                        },
+                        "required": ["event_id", "title", "start", "end"],
+                    },
+                },
+            },
+        ]
+
+    def get_tool_descriptions(self) -> List[str]:
+        return ["Calendar management tool providing today's events and update operations."]


### PR DESCRIPTION
## Summary
- integrate calendar store into workflow context
- expose new CalendarTool for manipulating daily events
- document the CalendarTool in tools tutorial

## Testing
- `pip install -e .[dev]`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mcp')*

------
https://chatgpt.com/codex/tasks/task_e_684e5d7ebbd88326a3147ec3132fa988