### PR TITLE
Add calendar integration and tool

### DIFF
--- a/evoagentx/core/runner.py
+++ b/evoagentx/core/runner.py
@@ -2,6 +2,7 @@ import asyncio
 from evoagentx.models import OpenAILLMConfig, OpenAILLM
 from evoagentx.workflow import WorkFlowGenerator, WorkFlowGraph, WorkFlow
 from evoagentx.agents import AgentManager
+from evoagentx.utils.calendar import get_today_events
 import os
 from dotenv import load_dotenv
 
@@ -33,4 +34,5 @@ async def run_workflow_async(goal: str) -> str:
     agent_manager.add_agents_from_workflow(workflow_graph, llm_config=llm_config)
 
     workflow = WorkFlow(graph=workflow_graph, agent_manager=agent_manager, llm=llm)
-    return await workflow.async_execute()
+    context = {"today_events": get_today_events(), "goal": goal}
+    return await workflow.async_execute(context)

--- a/evoagentx/tools/__init__.py
+++ b/evoagentx/tools/__init__.py
@@ -7,9 +7,10 @@ from .search_google_f import SearchGoogleFree
 from .search_wiki import SearchWiki
 from .search_google import SearchGoogle
 from .mcp import MCPClient, MCPToolkit
+from .calendar import CalendarTool
 
 
 __all__ = ["Tool", "BaseInterpreter", "DockerInterpreter", 
            "PythonInterpreter", "SearchBase", "SearchGoogleFree", "SearchWiki", "SearchGoogle",
-           "MCPClient", "MCPToolkit"]
+           "MCPClient", "MCPToolkit", "CalendarTool"]
 

--- a/evoagentx/tools/calendar.py
+++ b/evoagentx/tools/calendar.py
@@ -1,0 +1,93 @@
+from typing import Any, Callable, Dict, List
+from .tool import Tool
+from ..utils.calendar import get_today_events, add_event, remove_event, update_event
+
+
+class CalendarTool(Tool):
+    """Tool providing calendar operations."""
+
+    def __init__(self, name: str = "calendar", **kwargs):
+        super().__init__(name=name, **kwargs)
+
+    def get_today(self) -> List[Dict[str, Any]]:
+        return get_today_events()
+
+    def add_event(self, title: str, start: str, end: str) -> Dict[str, Any]:
+        return add_event(title, start, end)
+
+    def remove_event(self, event_id: int) -> Dict[str, Any]:
+        remove_event(event_id)
+        return {"ok": True}
+
+    def update_event(self, event_id: int, title: str, start: str, end: str) -> Dict[str, Any]:
+        return update_event(event_id, title, start, end)
+
+    def get_tools(self) -> List[Callable]:
+        return [self.get_today, self.add_event, self.remove_event, self.update_event]
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_today",
+                    "description": "Get today's calendar events",
+                    "parameters": {"type": "object", "properties": {}, "required": []},
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "add_event",
+                    "description": "Add a calendar event",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "title": {"type": "string", "description": "Event title"},
+                            "start": {"type": "string", "description": "Start time ISO"},
+                            "end": {"type": "string", "description": "End time ISO"},
+                        },
+                        "required": ["title", "start", "end"],
+                    },
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "remove_event",
+                    "description": "Remove a calendar event",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "event_id": {"type": "integer", "description": "Event identifier"}
+                        },
+                        "required": ["event_id"],
+                    },
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "update_event",
+                    "description": "Update a calendar event",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "event_id": {"type": "integer", "description": "Event identifier"},
+                            "title": {"type": "string", "description": "Event title"},
+                            "start": {"type": "string", "description": "Start time ISO"},
+                            "end": {"type": "string", "description": "End time ISO"},
+                        },
+                        "required": ["event_id", "title", "start", "end"],
+                    },
+                },
+            },
+        ]
+
+    def get_tool_descriptions(self) -> List[str]:
+        return [
+            "Get today's calendar events",
+            "Add a calendar event",
+            "Remove a calendar event",
+            "Update a calendar event",
+        ]

--- a/evoagentx/utils/__init__.py
+++ b/evoagentx/utils/__init__.py
@@ -1,0 +1,8 @@
+from .calendar import get_today_events, add_event, remove_event, update_event
+
+__all__ = [
+    "get_today_events",
+    "add_event",
+    "remove_event",
+    "update_event",
+]

--- a/evoagentx/utils/calendar.py
+++ b/evoagentx/utils/calendar.py
@@ -1,0 +1,55 @@
+import os
+import requests
+from typing import Any, Dict, List
+from ..core.logging import logger
+
+
+def _base_url() -> str:
+    return os.getenv("CALENDAR_API_URL", "http://localhost:8000").rstrip("/")
+
+
+def get_today_events() -> List[Dict[str, Any]]:
+    """Return today's events from the calendar API."""
+    url = f"{_base_url()}/calendar/today"
+    try:
+        resp = requests.get(url, timeout=5)
+        resp.raise_for_status()
+        return resp.json()
+    except Exception as e:
+        logger.warning(f"Failed to fetch today's events: {e}")
+        return []
+
+
+def add_event(title: str, start: str, end: str) -> Dict[str, Any]:
+    """Add a calendar event via the API."""
+    url = f"{_base_url()}/calendar/event"
+    try:
+        resp = requests.post(url, json={"title": title, "start": start, "end": end}, timeout=5)
+        resp.raise_for_status()
+        return resp.json()
+    except Exception as e:
+        logger.error(f"Failed to add event: {e}")
+        raise
+
+
+def remove_event(event_id: int) -> None:
+    """Remove an event by id."""
+    url = f"{_base_url()}/calendar/event/{event_id}"
+    try:
+        resp = requests.delete(url, timeout=5)
+        resp.raise_for_status()
+    except Exception as e:
+        logger.error(f"Failed to remove event: {e}")
+        raise
+
+
+def update_event(event_id: int, title: str, start: str, end: str) -> Dict[str, Any]:
+    """Update an existing calendar event."""
+    url = f"{_base_url()}/calendar/event/{event_id}"
+    try:
+        resp = requests.put(url, json={"title": title, "start": start, "end": end}, timeout=5)
+        resp.raise_for_status()
+        return resp.json()
+    except Exception as e:
+        logger.error(f"Failed to update event: {e}")
+        raise

--- a/tests/src/tools/test_calendar_tool.py
+++ b/tests/src/tools/test_calendar_tool.py
@@ -1,0 +1,13 @@
+import unittest
+from evoagentx.tools.calendar import CalendarTool
+
+class TestCalendarTool(unittest.TestCase):
+    def test_schemas(self):
+        tool = CalendarTool()
+        schemas = tool.get_tool_schemas()
+        self.assertEqual(len(schemas), 4)
+        names = [s["function"]["name"] for s in schemas]
+        self.assertEqual(names, ["get_today", "add_event", "remove_event", "update_event"])
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow passing today's schedule to `run_workflow_async`
- create a `CalendarTool` for managing events
- expose calendar utilities
- test CalendarTool schemas

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e5d7ebbd88326a3147ec3132fa988