### PR TITLE
Add docs for calendar and async workflow runner

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -138,3 +138,18 @@ print(output)
 
 For a complete working example, check out the [full workflow demo](https://github.com/EvoAgentX/EvoAgentX/blob/main/examples/workflow_demo.py).
 
+### Async Helper
+
+EvoAgentX also provides `run_workflow_async()` for convenience. This helper
+executes the workflow in one call and automatically passes today's calendar
+events as context so agents can reason about your schedule.
+
+```python
+import asyncio
+from evoagentx.core.runner import run_workflow_async
+
+result = asyncio.run(run_workflow_async("Generate html code for the Tetris game"))
+print(result)
+```
+
+

--- a/docs/tutorial/tools.md
+++ b/docs/tutorial/tools.md
@@ -473,6 +473,31 @@ today = calendar.get_today()
 - `remove_event(event_id)` – delete an event
 - `update_event(event_id, title, start, end)` – modify an event
 
+### 4.3 Usage Example
+
+```python
+calendar = CalendarTool()
+
+# Retrieve today's events
+today = calendar.get_today()
+print(today)
+
+# Add a new entry
+event = calendar.add_event(
+    title="Team Sync",
+    start="2025-01-10T09:00:00",
+    end="2025-01-10T09:30:00",
+)
+
+# Update the entry later
+calendar.update_event(
+    event_id=event["id"],
+    title="Team Sync (updated)",
+    start="2025-01-10T09:00:00",
+    end="2025-01-10T10:00:00",
+)
+```
+
 ---
 
 ## 5. MCP Tools


### PR DESCRIPTION
## Summary
- add async workflow runner example that passes calendar events
- document CalendarTool usage for adding, retrieving, and updating events

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for numpy, yaml, datasets, pydantic)*

------
https://chatgpt.com/codex/tasks/task_e_684e63f506388326ab9ab034fa73f71c