### PR TITLE
Add macOS Calendar integration

### DIFF
--- a/server/api/calendar.py
+++ b/server/api/calendar.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, HTTPException
 
-from server.models.schemas import Event, EventCreate
+from server.models.schemas import CalendarEvent, Event, EventCreate
+from server.core.macos_calendar import create_calendar_event
 from .calendar_store import calendar_store
 
 calendar_router = APIRouter(prefix="/calendar")
@@ -27,3 +28,12 @@ def delete_event(event_id: int):
         return {"ok": True}
     except KeyError:
         raise HTTPException(status_code=404, detail="Event not found")
+
+
+@calendar_router.post("/add-events")
+def add_events(events: list[CalendarEvent]):
+    """Add multiple events to the macOS Calendar."""
+
+    for e in events:
+        create_calendar_event(e.title, e.start, e.end, e.calendar_name)
+    return {"added": len(events)}

--- a/server/core/macos_calendar.py
+++ b/server/core/macos_calendar.py
@@ -1,0 +1,26 @@
+"""Utilities for interacting with the macOS Calendar via AppleScript."""
+
+from __future__ import annotations
+
+import subprocess
+from datetime import datetime
+
+
+def _format_as_applescript_date(dt: datetime) -> str:
+    """Return a date string formatted for AppleScript."""
+
+    return dt.strftime("%A, %B %d, %Y at %I:%M %p")
+
+
+def create_calendar_event(title: str, start: datetime, end: datetime, calendar_name: str = "Home") -> None:
+    """Create an event in the macOS Calendar using AppleScript."""
+
+    start_str = _format_as_applescript_date(start)
+    end_str = _format_as_applescript_date(end)
+    script = (
+        f'tell application "Calendar" '
+        f'to tell calendar "{calendar_name}" '
+        f'to make new event with properties {{summary:"{title}", start date:date "{start_str}", end date:date "{end_str}"}}'
+    )
+    subprocess.run(["osascript", "-e", script], check=True)
+

--- a/server/models/schemas.py
+++ b/server/models/schemas.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from pydantic import BaseModel
 
 
@@ -22,3 +23,12 @@ class EventCreate(EventBase):
 
 class Event(EventBase):
     id: int
+
+
+class CalendarEvent(BaseModel):
+    """Event information for adding to the macOS Calendar."""
+
+    title: str
+    start: datetime
+    end: datetime
+    calendar_name: str = "Home"


### PR DESCRIPTION
## Summary
- implement CalendarEvent schema
- create helper for AppleScript Calendar events
- add `/calendar/add-events` endpoint

## Testing
- `ruff check server/core/macos_calendar.py server/api/calendar.py server/models/schemas.py`
- `pytest tests/src/tools/test_calendar_tool.py -q` *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_684e6706b45483269ec769e7fe15bb1a