### PR TITLE
Add macOS Calendar integration

### DIFF
--- a/server/api/calendar.py
+++ b/server/api/calendar.py
@@ -1,9 +1,27 @@
 from fastapi import APIRouter, HTTPException
+import subprocess
+from datetime import datetime
 
-from server.models.schemas import Event, EventCreate
+from server.models.schemas import Event, EventCreate, CalendarEvent
 from .calendar_store import calendar_store
 
 calendar_router = APIRouter(prefix="/calendar")
+
+
+def create_calendar_event(title: str, start: str, end: str, calendar_name: str = "Home") -> None:
+    """Create a macOS Calendar event via AppleScript."""
+    start_dt = datetime.fromisoformat(start)
+    end_dt = datetime.fromisoformat(end)
+    start_str = start_dt.strftime("%A, %B %d, %Y at %I:%M %p")
+    end_str = end_dt.strftime("%A, %B %d, %Y at %I:%M %p")
+    script = (
+        f'tell application "Calendar"\n'
+        f'  tell calendar "{calendar_name}"\n'
+        f'    make new event with properties {{summary:"{title}", start date:date "{start_str}", end date:date "{end_str}"}}\n'
+        f'  end tell\n'
+        f'end tell'
+    )
+    subprocess.run(["osascript", "-e", script], check=True)
 
 @calendar_router.get("/today", response_model=list[Event])
 def get_today():
@@ -27,3 +45,11 @@ def delete_event(event_id: int):
         return {"ok": True}
     except KeyError:
         raise HTTPException(status_code=404, detail="Event not found")
+
+
+@calendar_router.post("/add-events")
+def add_events(events: list[CalendarEvent]):
+    """Add multiple events to the macOS Calendar."""
+    for e in events:
+        create_calendar_event(e.title, e.start, e.end, e.calendar_name)
+    return {"added": len(events)}

--- a/server/models/schemas.py
+++ b/server/models/schemas.py
@@ -22,3 +22,12 @@ class EventCreate(EventBase):
 
 class Event(EventBase):
     id: int
+
+
+class CalendarEvent(BaseModel):
+    """Input schema for creating macOS Calendar events."""
+
+    title: str
+    start: str
+    end: str
+    calendar_name: str = "Home"


### PR DESCRIPTION
## Summary
- create `CalendarEvent` schema for AppleScript calendar events
- add AppleScript event creator `create_calendar_event`
- expose new route `POST /calendar/add-events` that calls AppleScript

## Testing
- `pip install -e .[dev]`
- `pytest -q` *(fails: ConnectionError to localhost calendar API)*

------
https://chatgpt.com/codex/tasks/task_e_684e6706b45483269ec769e7fe15bb1a