### PR TITLE
Add macOS calendar route

### DIFF
--- a/server/api/calendar.py
+++ b/server/api/calendar.py
@@ -1,9 +1,25 @@
 from fastapi import APIRouter, HTTPException
 
-from server.models.schemas import Event, EventCreate
+from server.models.schemas import Event, EventCreate, CalendarEvent
+from datetime import datetime
+import subprocess
 from .calendar_store import calendar_store
 
 calendar_router = APIRouter(prefix="/calendar")
+
+
+def create_calendar_event(title: str, start: datetime, end: datetime, calendar_name: str = "Home") -> None:
+    """Create a macOS Calendar event via AppleScript."""
+    start_str = start.strftime("%A, %B %d, %Y at %I:%M %p")
+    end_str = end.strftime("%A, %B %d, %Y at %I:%M %p")
+    script = (
+        'tell application "Calendar"\n'
+        f'  tell calendar "{calendar_name}"\n'
+        f'    make new event with properties {{summary:"{title}", start date:date "{start_str}", end date:date "{end_str}"}}\n'
+        '  end tell\n'
+        'end tell'
+    )
+    subprocess.run(["osascript", "-e", script], check=True)
 
 @calendar_router.get("/today", response_model=list[Event])
 def get_today():
@@ -27,3 +43,11 @@ def delete_event(event_id: int):
         return {"ok": True}
     except KeyError:
         raise HTTPException(status_code=404, detail="Event not found")
+
+
+@calendar_router.post("/add-events")
+def add_calendar_events(events: list[CalendarEvent]):
+    """Add multiple events to macOS Calendar."""
+    for event in events:
+        create_calendar_event(event.title, event.start, event.end, event.calendar_name)
+    return {"added": len(events)}

--- a/server/models/schemas.py
+++ b/server/models/schemas.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from pydantic import BaseModel
 
 
@@ -22,3 +23,12 @@ class EventCreate(EventBase):
 
 class Event(EventBase):
     id: int
+
+
+class CalendarEvent(BaseModel):
+    """Schema for adding events to macOS Calendar."""
+
+    title: str
+    start: datetime
+    end: datetime
+    calendar_name: str = "Home"


### PR DESCRIPTION
## Summary
- create `CalendarEvent` model for adding to macOS Calendar
- add `create_calendar_event` AppleScript helper
- expose `/calendar/add-events` route to post events for macOS Calendar

## Testing
- `pip install -e .[dev]`
- `pytest -q` *(fails: 3 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_684e6706b45483269ec769e7fe15bb1a