### PR TITLE
Add macOS Calendar event route

### DIFF
--- a/server/api/calendar.py
+++ b/server/api/calendar.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, HTTPException
 
-from server.models.schemas import Event, EventCreate
+from server.models.schemas import Event, EventCreate, MacCalendarEvent
+from server.core.macos_calendar import create_calendar_event
 from .calendar_store import calendar_store
 
 calendar_router = APIRouter(prefix="/calendar")
@@ -27,3 +28,11 @@ def delete_event(event_id: int):
         return {"ok": True}
     except KeyError:
         raise HTTPException(status_code=404, detail="Event not found")
+
+
+@calendar_router.post("/add-events")
+def add_events(events: list[MacCalendarEvent]):
+    """Add multiple events to macOS Calendar via AppleScript."""
+    for e in events:
+        create_calendar_event(e.title, e.start, e.end, e.calendar_name)
+    return {"added": len(events)}

--- a/server/core/macos_calendar.py
+++ b/server/core/macos_calendar.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from datetime import datetime
+import subprocess
+
+
+def create_calendar_event(
+    title: str,
+    start: datetime,
+    end: datetime,
+    calendar_name: str = "Home",
+) -> None:
+    """Create an event in macOS Calendar using AppleScript."""
+    start_str = start.strftime("%A, %B %d, %Y at %I:%M %p")
+    end_str = end.strftime("%A, %B %d, %Y at %I:%M %p")
+
+    title_esc = title.replace("\"", "\\\"")
+    cal_esc = calendar_name.replace("\"", "\\\"")
+
+    script_lines = [
+        'tell application "Calendar"',
+        f'tell calendar "{cal_esc}"',
+        f'make new event with properties {{summary:"{title_esc}", start date:date "{start_str}", end date:date "{end_str}"}}',
+        'end tell',
+        'end tell',
+    ]
+
+    cmd = ["osascript"]
+    for line in script_lines:
+        cmd.extend(["-e", line])
+    subprocess.run(cmd, check=True)

--- a/server/models/schemas.py
+++ b/server/models/schemas.py
@@ -1,4 +1,5 @@
 from pydantic import BaseModel
+from datetime import datetime
 
 
 class RunRequest(BaseModel):
@@ -22,3 +23,12 @@ class EventCreate(EventBase):
 
 class Event(EventBase):
     id: int
+
+
+class MacCalendarEvent(BaseModel):
+    """Schema for creating macOS Calendar events."""
+
+    title: str
+    start: datetime
+    end: datetime
+    calendar_name: str = "Home"


### PR DESCRIPTION
## Summary
- create `MacCalendarEvent` schema for incoming requests
- add helper to run AppleScript and create calendar events
- expose `POST /calendar/add-events` API endpoint

## Testing
- `pip install -e .[dev]`
- `pytest -q` *(fails: 3 errors during collection)*
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_684e6706b45483269ec769e7fe15bb1a