### PR TITLE
Fix vector store factory and config

### DIFF
--- a/evoagentx/storages/storages_config.py
+++ b/evoagentx/storages/storages_config.py
@@ -16,10 +16,12 @@ class DBConfig(BaseConfig):
 
 
 class VectorStoreConfig(BaseConfig):
-    """
-    Placeholder for settings related to vector databases (e.g., Qdrant, Chroma).
-    """
-    pass
+    """Configuration for vector database backends."""
+
+    provider: str = Field(
+        default="",
+        description="Name of the vector store provider (e.g., 'qdrant', 'chroma')",
+    )
 
 
 class GraphStoreConfig(BaseConfig):

--- a/evoagentx/utils/factory.py
+++ b/evoagentx/utils/factory.py
@@ -69,19 +69,17 @@ class VectorStoreFactory:
         "faiss":  "mem0.vector_stores.faiss.FAISS",
     }
 
-    @classmethod                     
-    def create(cls, provider: str, config: "VectorStoreConfig | dict"):
-        """
-        Create a vector store instance for the specified provider.
-        """
-        from ..storages import storages_config     # avoid circular import
+    @classmethod
+    def create(cls, config: "VectorStoreConfig | dict"):
+        """Create a vector store instance from the provided configuration."""
+        from ..storages import storages_config  # avoid circular import
 
-        # accept either a dataclass / pydantic model or plain dict
         if isinstance(config, storages_config.VectorStoreConfig):
-            cfg_dict   = config.model_dump()
-            provider   = config.provider           # keep single source of truth
+            cfg_dict = config.model_dump()
+            provider = config.provider
         else:
             cfg_dict = dict(config)
+            provider = cfg_dict.get("provider", "")
 
         class_path = cls.provider_to_class.get(provider)
         if not class_path:

--- a/tests/test_utils_extra.py
+++ b/tests/test_utils_extra.py
@@ -67,7 +67,8 @@ def test_factory_db_supported(monkeypatch):
 
 def test_factory_vector_and_graph():
     cfg = VectorStoreConfig()
-    assert factory.VectorStoreFactory().create(config=cfg) is None
+    with pytest.raises(ValueError):
+        factory.VectorStoreFactory.create(cfg)
     assert factory.GraphStoreFactory.create(config=cfg) is None
 def test_factory_db_unsupported():
     with pytest.raises(ValueError):

--- a/tests/test_utils_quickfill.py
+++ b/tests/test_utils_quickfill.py
@@ -82,6 +82,7 @@ def test_db_factory_unsupported():
 class _DummyCfg:
     # Define the necessary attributes and methods expected by the factory
     def __init__(self):
+        self.provider = "qdrant"
         self.some_attribute = "some_value"
 
 
@@ -113,12 +114,12 @@ def test_vector_factory_stub(monkeypatch):
                         lambda path: stub.Qdrant)
 
     # ------------------------------------------------------------------
-    # 3.  Monkey-patch VectorStoreFactory.create but keep its real
-    #     signature: (provider, config)
+    # 3.  Monkey-patch VectorStoreFactory.create with its real
+    #     signature: (config)
     # ------------------------------------------------------------------
-    def _fake_create(cls, provider: str, config=None):
-        # In the real factory `provider` decides which class to load.
-        assert provider == "qdrant"
+    def _fake_create(cls, config=None):
+        # Provider should be read from the config
+        assert getattr(config, "provider", None) == "qdrant"
         return factory.load_class(
             "mem0.vector_stores.qdrant.Qdrant"
         )()
@@ -131,5 +132,5 @@ def test_vector_factory_stub(monkeypatch):
     # 4.  Exercise the stubbed factory
     # ------------------------------------------------------------------
     cfg = _DummyCfg()
-    got = factory.VectorStoreFactory.create("qdrant", cfg)
+    got = factory.VectorStoreFactory.create(cfg)
     assert got == "qdrant-instance"


### PR DESCRIPTION
## Summary
- add provider attribute to `VectorStoreConfig`
- update `VectorStoreFactory` to read provider from the config
- adjust smoke tests for new signature
- adapt vector factory stub in tests

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fd3f8f44483268389548361946374