### PR TITLE
Add SQLite memory persistence

### DIFF
--- a/evoagentx/memory/__init__.py
+++ b/evoagentx/memory/__init__.py
@@ -1,5 +1,16 @@
 from .memory import BaseMemory, ShortTermMemory
 from .long_term_memory import LongTermMemory
 from .memory_manager import MemoryManager
+from .memory_object import MemoryObject
+from .store import MemoryStore
+from .sqlite_store import SQLiteStore
 
-__all__ = ["BaseMemory", "ShortTermMemory", "LongTermMemory", "MemoryManager"]
+__all__ = [
+    "BaseMemory",
+    "ShortTermMemory",
+    "LongTermMemory",
+    "MemoryManager",
+    "MemoryObject",
+    "MemoryStore",
+    "SQLiteStore",
+]

--- a/evoagentx/memory/memory_object.py
+++ b/evoagentx/memory/memory_object.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass
+from typing import Any, Dict
+
+@dataclass
+class MemoryObject:
+    """Simple serializable memory unit."""
+
+    id: str
+    content: Any
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"id": self.id, "content": self.content}
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "MemoryObject":
+        return cls(id=data["id"], content=data["content"])

--- a/evoagentx/memory/sqlite_store.py
+++ b/evoagentx/memory/sqlite_store.py
@@ -1,0 +1,39 @@
+import sqlite3
+import json
+from pathlib import Path
+from typing import Iterable
+
+from .store import MemoryStore
+from .memory_object import MemoryObject
+
+
+class SQLiteStore(MemoryStore):
+    """SQLite-backed implementation of ``MemoryStore``."""
+
+    def __init__(self, path: str | Path = "memory.db"):
+        self._path = Path(path)
+        self._conn = sqlite3.connect(self._path)
+        self._conn.execute(
+            "CREATE TABLE IF NOT EXISTS memory (id TEXT PRIMARY KEY, data TEXT)"
+        )
+
+    def save(self, obj: MemoryObject) -> None:
+        data = json.dumps(obj.to_dict())
+        self._conn.execute(
+            "REPLACE INTO memory (id, data) VALUES (?, ?)", (obj.id, data)
+        )
+        self._conn.commit()
+
+    def load(self, obj_id: str) -> MemoryObject | None:
+        row = self._conn.execute(
+            "SELECT data FROM memory WHERE id = ?", (obj_id,)
+        ).fetchone()
+        return MemoryObject.from_dict(json.loads(row[0])) if row else None
+
+    def delete(self, obj_id: str) -> None:
+        self._conn.execute("DELETE FROM memory WHERE id = ?", (obj_id,))
+        self._conn.commit()
+
+    def all(self) -> Iterable[MemoryObject]:
+        rows = self._conn.execute("SELECT data FROM memory").fetchall()
+        return [MemoryObject.from_dict(json.loads(r[0])) for r in rows]

--- a/evoagentx/memory/store.py
+++ b/evoagentx/memory/store.py
@@ -1,0 +1,15 @@
+from abc import ABC, abstractmethod
+from typing import Iterable
+
+class MemoryStore(ABC):
+    @abstractmethod
+    def save(self, obj: "MemoryObject") -> None: ...
+
+    @abstractmethod
+    def load(self, obj_id: str) -> "MemoryObject | None": ...
+
+    @abstractmethod
+    def delete(self, obj_id: str) -> None: ...
+
+    @abstractmethod
+    def all(self) -> Iterable["MemoryObject"]: ...

--- a/tests/test_memory_restart.py
+++ b/tests/test_memory_restart.py
@@ -1,0 +1,14 @@
+from evoagentx.memory.sqlite_store import SQLiteStore
+from evoagentx.memory.memory_object import MemoryObject
+
+
+def test_state_persists(tmp_path):
+    path = tmp_path / "mem.db"
+    store1 = SQLiteStore(path=path)
+    store1.save(MemoryObject(id="foo", content="bar"))
+
+    store2 = SQLiteStore(path=path)
+    reloaded = store2.load("foo")
+
+    assert reloaded is not None
+    assert reloaded.content == "bar"


### PR DESCRIPTION
## Summary
- define `MemoryStore` interface
- implement `SQLiteStore` with persistence
- add simple `MemoryObject` dataclass
- expose new modules in memory package
- ensure state persists across restarts with new unit test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fdbb6d80c8326a0b10ee6c4dd9fd9