### PR TITLE
Fix import error in memory store

### DIFF
--- a/evoagentx/memory/store.py
+++ b/evoagentx/memory/store.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from typing import Iterable
-from memory_object import MemoryObject
+from .memory_object import MemoryObject
 
 class MemoryStore(ABC):
     @abstractmethod


### PR DESCRIPTION
## Summary
- update `evoagentx.memory.store` to use a relative import for `MemoryObject`

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fe4244d688326af59f485e75974ed