### PR TITLE
Add SQLiteStore edge tests & complete SEWWorkFlowScheme

### DIFF
--- a/tests/src/optimizers/test_sew_workflow_scheme.py
+++ b/tests/src/optimizers/test_sew_workflow_scheme.py
@@ -32,3 +32,15 @@ def test_generate_steps(name, expected):
 def test_unknown_scheme_raises():
     with pytest.raises(ValueError):
         SEWWorkFlowScheme("does_not_exist").generate_steps()
+
+@pytest.mark.parametrize(
+    "scheme,expected_fields",
+    [
+        (SEWWorkFlowScheme("basic"), SimpleNamespace(name="basic", steps=["ingest", "plan", "execute"])),
+        (SEWWorkFlowScheme("extended"), SimpleNamespace(name="extended", steps=["ingest", "analyze", "plan", "review", "execute"])),
+        (SEWWorkFlowScheme("minimal"), SimpleNamespace(name="minimal", steps=["ingest", "execute"])),
+    ],
+)
+def test_scheme_fields(scheme, expected_fields):
+    assert scheme.name == expected_fields.name
+    assert scheme.generate_steps() == expected_fields.steps

--- a/tests/test_sqlite_store.py
+++ b/tests/test_sqlite_store.py
@@ -1,0 +1,31 @@
+import pytest
+from evoagentx.memory.sqlite_store import SQLiteStore
+from evoagentx.memory.memory_object import MemoryObject
+
+
+@pytest.mark.parametrize(
+    "case,obj_id,expected",
+    [
+        ("delete", "one", {"two"}),
+        ("all", None, {"one", "two"}),
+        ("load_missing", "ghost", None),
+    ],
+)
+def test_sqlite_store_edge_cases(tmp_path, case, obj_id, expected):
+    path = tmp_path / "mem.db"
+    store = SQLiteStore(path=path)
+    store.save(MemoryObject(id="one", content=1))
+    store.save(MemoryObject(id="two", content=2))
+
+    if case == "delete":
+        store.delete(obj_id)
+        # reopen to ensure persistence
+        store = SQLiteStore(path=path)
+        assert store.load(obj_id) is None
+        assert {o.id for o in store.all()} == expected
+    elif case == "all":
+        # reload to ensure results come from DB
+        store = SQLiteStore(path=path)
+        assert {o.id for o in store.all()} == expected
+    elif case == "load_missing":
+        assert store.load(obj_id) is expected


### PR DESCRIPTION
## Summary
- add parametrized edge case tests for SQLiteStore
- exercise every SEWWorkFlowScheme using table-driven checks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fe929710c83268a4d210df2e5cfcb