### PR TITLE
Add RedisStore implementation with tests

### DIFF
--- a/evoagentx/memory/__init__.py
+++ b/evoagentx/memory/__init__.py
@@ -5,6 +5,7 @@ from .memory_object import MemoryObject
 from .store import MemoryStore
 from .sqlite_store import SQLiteStore
 
+from .redis_store import RedisStore
 __all__ = [
     "BaseMemory",
     "ShortTermMemory",
@@ -13,4 +14,5 @@ __all__ = [
     "MemoryObject",
     "MemoryStore",
     "SQLiteStore",
+    "RedisStore",
 ]

--- a/evoagentx/memory/redis_store.py
+++ b/evoagentx/memory/redis_store.py
@@ -1,0 +1,38 @@
+import json
+from typing import Iterable
+import redis
+
+from .store import MemoryStore
+from .memory_object import MemoryObject
+
+class RedisStore(MemoryStore):
+    """Redis-backed implementation of ``MemoryStore``.
+
+    Args:
+        host: Redis host (default ``'localhost'``)
+        port: Redis port (default ``6379``)
+        db: Redis database number (default ``0``)
+    """
+
+    def __init__(self, host: str = 'localhost', port: int = 6379, db: int = 0):
+        self._client = redis.Redis(host=host, port=port, db=db, decode_responses=True)
+
+    def save(self, obj: MemoryObject) -> None:
+        data = json.dumps(obj.to_dict())
+        self._client.set(obj.id, data)
+
+    def load(self, obj_id: str) -> MemoryObject | None:
+        raw = self._client.get(obj_id)
+        return MemoryObject.from_dict(json.loads(raw)) if raw is not None else None
+
+    def delete(self, obj_id: str) -> None:
+        self._client.delete(obj_id)
+
+    def all(self) -> Iterable[MemoryObject]:
+        keys = self._client.keys()
+        objects = []
+        for k in keys:
+            raw = self._client.get(k)
+            if raw:
+                objects.append(MemoryObject.from_dict(json.loads(raw)))
+        return objects

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,8 @@ dev = [
     "pytest-asyncio",
     "pytest-subtests",
     "pytest-json-report",
-    "ruff"
+    "ruff",
+    "fakeredis"
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ pytest-subtests
 pytest-json-report
 ruff
 
+fakeredis
 sympy
 stopit
 scipy

--- a/tests/test_redis_store.py
+++ b/tests/test_redis_store.py
@@ -1,0 +1,36 @@
+import pytest
+import fakeredis
+
+from evoagentx.memory.redis_store import RedisStore
+from evoagentx.memory.memory_object import MemoryObject
+
+@pytest.fixture(autouse=True)
+def fake_redis(monkeypatch):
+    fake = fakeredis.FakeRedis(decode_responses=True)
+    monkeypatch.setattr('evoagentx.memory.redis_store.redis.Redis', lambda **kwargs: fake)
+    return fake
+
+def test_save_and_load():
+    store = RedisStore()
+    obj = MemoryObject(id='a', content={'x': 42})
+    store.save(obj)
+    loaded = store.load('a')
+    assert loaded is not None
+    assert loaded.id == 'a'
+    assert loaded.content == {'x': 42}
+
+def test_delete():
+    store = RedisStore()
+    obj = MemoryObject(id='b', content='foo')
+    store.save(obj)
+    store.delete('b')
+    assert store.load('b') is None
+
+def test_all():
+    store = RedisStore()
+    objs = [MemoryObject(id=str(i), content=i) for i in range(3)]
+    for o in objs:
+        store.save(o)
+    all_objs = store.all()
+    assert {o.id for o in all_objs} == {'0','1','2'}
+


### PR DESCRIPTION
## Summary
- implement RedisStore as a MemoryStore backend
- expose RedisStore from memory package
- add fakeredis dependency for dev/testing
- include new unit tests for RedisStore

## Testing
- `ruff check evoagentx/memory/redis_store.py tests/test_redis_store.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ff1c7efe88326bdae02df13d7e588