### PR TITLE
Add SEWWorkFlowScheme tests and coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@
 </h2>
 
 <div align="center">
-![CI](https://github.com/EvoAgentX/EvoAgentX/actions/workflows/ci.yml/badge.svg)
+![CI](https://github.com/MysteriousMagpie/EvoAgentX/actions/workflows/ci.yml/badge.svg)
+
+[![Coverage Status](https://img.shields.io/github/actions/workflow/status/MysteriousMagpie/EvoAgentX/coverage.yml?branch=main)](https://github.com/MysteriousMagpie/EvoAgentX/actions/workflows/coverage.yml)
 [![Coverage](https://img.shields.io/badge/coverage-branch--80%25-brightgreen)](./.github/workflows/ci.yml)
 
 [![EvoAgentX Homepage](https://img.shields.io/badge/EvoAgentX-Homepage-blue?logo=homebridge)](https://evoagentx.org/)

--- a/tests/test_sew_workflow_scheme.py
+++ b/tests/test_sew_workflow_scheme.py
@@ -1,0 +1,21 @@
+import pytest
+from evoagentx.optimizers.sew_optimizer import SEWWorkFlowScheme, VALID_SCHEMES
+
+class DummyGraph:
+    """A minimal stub that SEWWorkFlowScheme accepts."""
+    def __init__(self):
+        self.nodes = []
+
+@pytest.mark.parametrize("scheme", VALID_SCHEMES)
+def test_convert_to_valid_schemes(scheme):
+    graph = DummyGraph()
+    scheme_str = SEWWorkFlowScheme(graph).convert_to_scheme(scheme)
+    # Should return a string representation
+    assert isinstance(scheme_str, str)
+
+@pytest.mark.parametrize("bad_scheme", ["", "INVALID", None])
+def test_convert_invalid_scheme_raises(bad_scheme):
+    graph = DummyGraph()
+    with pytest.raises(ValueError) as exc:
+        SEWWorkFlowScheme(graph).convert_to_scheme(bad_scheme)
+    assert "Invalid scheme" in str(exc.value)


### PR DESCRIPTION
## Summary
- add pytest coverage badge in README
- test `SEWWorkFlowScheme.convert_to_scheme`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ffbb9a6a883268e8b1b72998b2794