### PR TITLE
Add generic optimizer runner and integration tests

### DIFF
--- a/evoagentx/core/optimization_runner.py
+++ b/evoagentx/core/optimization_runner.py
@@ -1,0 +1,30 @@
+import argparse
+from typing import Callable, Any
+from .logging import logger
+from ..optimizers import get_optimizer, list_optimizers
+
+
+def run(objective: Callable[[Any], float], optimizer: str = "textgrad", **optimizer_params):
+    """Run optimization with the requested optimizer."""
+    try:
+        opt = get_optimizer(optimizer, **optimizer_params)
+    except ValueError:
+        print(f"Unknown optimizer '{optimizer}'. Valid options: {list_optimizers()}")
+        raise
+    return opt.optimize(objective)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run optimization with a selected optimizer")
+    parser.add_argument("--optimizer", default="textgrad", help="Optimizer name")
+    args = parser.parse_args()
+
+    def objective(x):
+        return x ** 2
+
+    result = run(objective, optimizer=args.optimizer)
+    logger.info(f"Optimization result: {result}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_optimizer_integration.py
+++ b/tests/test_optimizer_integration.py
@@ -1,0 +1,33 @@
+import pytest
+from evoagentx.core.optimization_runner import run
+from evoagentx.optimizers import Optimizer, _optimizers
+
+
+class DummyOptimizer(Optimizer):
+    def __init__(self, value=42):
+        self.value = value
+
+    def optimize(self, objective, **kwargs):
+        return self.value
+
+
+@pytest.fixture(autouse=True)
+def patch_registry(monkeypatch):
+    monkeypatch.setitem(_optimizers, "textgrad", DummyOptimizer)
+    monkeypatch.setitem(_optimizers, "sew", DummyOptimizer)
+    yield
+    _optimizers.pop("textgrad", None)
+    _optimizers.pop("sew", None)
+
+
+@pytest.mark.parametrize("name,expected", [
+    ("textgrad", 42),
+    ("sew", 42),
+    ("random_search", 0.5),
+])
+def test_optimizer_integration(name, expected):
+    if name == "random_search":
+        result = run(lambda x: x**2, optimizer=name, iterations=1, sampler=lambda: 0.5)
+    else:
+        result = run(lambda x: x**2, optimizer=name, value=42)
+    assert result == expected


### PR DESCRIPTION
## Summary
- add `optimization_runner` module for selecting optimizers by name
- implement integration test to ensure optimizers are loaded through the registry

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ffde137748326aa4959d4571d54ad