### PR TITLE
Add development guide

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,65 @@
+# Development Guide
+
+This page explains the layout of the repository and how to set up a local development environment.
+
+## Repository Structure
+
+- **`evoagentx/`** – Core Python library containing agents, tools, models and workflow logic.
+- **`examples/`** – Sample scripts and workflows demonstrating how to use EvoAgentX.
+- **`server/`** – FastAPI backend for running workflows and serving a REST API.
+- **`client/`** – Vite + React front‑end for interacting with the backend.
+- **`intelligence-parser/`** – Stand‑alone TypeScript utility package.
+- **`tests/`** – Unit tests for the Python modules and components.
+- **`docs/`** – MkDocs documentation source files.
+- **`run_evoagentx.py`** – Simple script to generate and run a workflow from a goal.
+
+## Local Setup
+
+Install the Python dependencies in development mode:
+
+```bash
+pip install -e .[dev]
+# or
+pip install -r requirements.txt
+```
+
+Set your `OPENAI_API_KEY` as described in the [Quickstart Guide](quickstart.md#api-key--llm-setup).
+
+## Running Tests
+
+Execute the unit tests before submitting changes:
+
+```bash
+pytest -q
+```
+
+## Building the Documentation
+
+The documentation site is built with MkDocs. You can preview it locally with:
+
+```bash
+mkdocs serve
+```
+
+The site configuration is defined in `mkdocs.yml`.
+
+## Full‑Stack Example
+
+The repository also includes a small FastAPI server and React client. To try them:
+
+```bash
+# Backend
+python -m venv .venv
+source .venv/bin/activate
+pip install -r server/requirements.txt
+uvicorn server.main:app --reload
+```
+
+```bash
+# Frontend
+cd client
+pnpm install
+pnpm dev
+```
+
+See the [README](../README.md#quick-start-full-stack) for details.

--- a/docs/zh/development.md
+++ b/docs/zh/development.md
@@ -1,0 +1,65 @@
+# 开发指南
+
+本文档介绍仓库结构以及在本地设置开发环境的方法。
+
+## 仓库结构
+
+- **`evoagentx/`** – 核心 Python 库，包含代理、工具、模型和工作流逻辑。
+- **`examples/`** – 示例脚本和工作流。
+- **`server/`** – 基于 FastAPI 的后端服务。
+- **`client/`** – Vite + React 前端项目。
+- **`intelligence-parser/`** – 独立的 TypeScript 工具包。
+- **`tests/`** – Python 单元测试。
+- **`docs/`** – MkDocs 文档源码。
+- **`run_evoagentx.py`** – 根据目标生成并执行工作流的脚本。
+
+## 环境搭建
+
+安装开发依赖：
+
+```bash
+pip install -e .[dev]
+# 或者
+pip install -r requirements.txt
+```
+
+按照 [快速上手](quickstart.md#api%E9%92%A5--llm-%E9%85%8D%E7%BD%AE) 中的说明设置 `OPENAI_API_KEY`。
+
+## 运行测试
+
+提交代码前请确保测试通过：
+
+```bash
+pytest -q
+```
+
+## 构建文档
+
+文档站点由 MkDocs 构建，可使用以下命令本地预览：
+
+```bash
+mkdocs serve
+```
+
+站点配置位于 `mkdocs.yml`。
+
+## 全栈示例
+
+仓库还提供一个简单的 FastAPI 后端和 React 前端，运行方法：
+
+```bash
+# 后端
+python -m venv .venv
+source .venv/bin/activate
+pip install -r server/requirements.txt
+uvicorn server.main:app --reload
+```
+
+```bash
+# 前端
+cd client
+pnpm install
+pnpm dev
+```
+
+更多细节参见 [README](../README-zh.md#quick-start-full-stack)。

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -210,6 +210,7 @@ plugins:
               - Benchmark: api/benchmark.md
               - Evaluators: api/evaluators.md
               - Optimizers: api/optimizers.md
+              - Development Guide: development.md
 
         - locale: zh
           name: 中文
@@ -248,3 +249,4 @@ plugins:
               - 基准测试接口: api/benchmark.md
               - 评估器接口: api/evaluators.md
               - 优化器接口: api/optimizers.md
+              - 开发指南: development.md


### PR DESCRIPTION
## Summary
- document repo structure and developer setup in a new Development Guide
- provide a Chinese translation of the guide
- link the guide from the documentation navigation

## Testing
- `pytest -q` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_685004bde8ac8326817fabf03547a7db