### PR TITLE
feat(docker): add resource limits & multi-runtime to DockerInterpreter

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,9 +11,15 @@ jobs:
         os: ['ubuntu-latest']
         python-version: ['3.10', '3.12']
 
+    services:
+      docker:
+        image: docker:dind
+        options: --privileged
+
     runs-on: ${{ matrix.os }}
     env:
       runtag: ${{ matrix.os }}-${{ matrix.python-version }}
+      RUN_DOCKER_TESTS: "true"
 
     steps:
      - name: Checkout

--- a/docs/api/docker_interpreter.md
+++ b/docs/api/docker_interpreter.md
@@ -1,0 +1,28 @@
+# DockerInterpreter
+
+`DockerInterpreter` executes user code inside Docker containers with resource limits.
+
+## Usage
+```python
+from evoagentx.tools.interpreter_docker import DockerInterpreter, DockerLimits
+
+limits = DockerLimits(memory="256m", cpus="0.5", timeout=10)
+interpreter = DockerInterpreter(runtime="python:3.11", limits=limits)
+print(interpreter.execute("print('hello')", "python"))
+```
+
+## Limit Fields
+- `memory`: Docker memory limit (default `512m`)
+- `cpus`: CPU cores allowed (default `1.0`)
+- `pids`: Maximum process count (default `64`)
+- `timeout`: Host-side timeout in seconds (default `20`)
+
+## Allowed Runtimes
+- `python:3.11` → `python:3.11-slim`
+- `node:20` → `node:20-slim`
+- `python:3.11-gpu` → `nvidia/cuda:12.4.0-runtime-ubuntu22.04`
+
+Use the `runtime` argument when creating the interpreter. Unsupported values raise `ValueError`.
+
+GPU images require a Docker setup with GPU support.
+

--- a/evoagentx/benchmark/__init__.py
+++ b/evoagentx/benchmark/__init__.py
@@ -18,7 +18,6 @@ __all__ = [
     "AFlowHumanEval", 
     "AFlowMBPP", 
     "AFlowHotPotQA",
-    "AFlowGSM8K"
+    "AFlowGSM8K",
+    "TextGenBenchmark",
 ]
-
-__all__.append("TextGenBenchmark")

--- a/evoagentx/tools/interpreter_docker.py
+++ b/evoagentx/tools/interpreter_docker.py
@@ -154,13 +154,20 @@ class DockerInterpreter(BaseInterpreter):
             raise RuntimeError(f"Docker daemon is not running: {e}")
 
         # Run the container using the image with resource limits
+        try:
+            cpus = float(self.limits.cpus)
+            if cpus <= 0:
+                raise ValueError
+        except Exception:
+            raise ValueError(f"Invalid CPU limit: {self.limits.cpus}")
+
         self.container = self.client.containers.run(
             image_tag,
             detach=True,
             command=self.container_command,
             working_dir=self.container_directory,
             mem_limit=self.limits.memory,
-            cpus=self.limits.cpus,
+            nano_cpus=int(cpus * 1_000_000_000),
             pids_limit=self.limits.pids,
         )
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -205,7 +205,8 @@ plugins:
               - Workflow: api/workflow.md
               - Storages: api/storages.md
               - Memory: api/memory.md
-              - Tools: api/tools.md 
+              - Tools: api/tools.md
+              - Docker Interpreter: api/docker_interpreter.md
               - Actions: api/actions.md
               - Benchmark: api/benchmark.md
               - Evaluators: api/evaluators.md
@@ -244,7 +245,8 @@ plugins:
               - 工作流接口: api/workflow.md
               - 存储模块: api/storages.md
               - 记忆模块: api/memory.md
-              - 工具集接口: api/tools.md 
+              - 工具集接口: api/tools.md
+              - Docker 解释器: api/docker_interpreter.md
               - 动作接口: api/actions.md
               - 基准测试接口: api/benchmark.md
               - 评估器接口: api/evaluators.md

--- a/tests/docker/test_memory_limit.py
+++ b/tests/docker/test_memory_limit.py
@@ -1,0 +1,12 @@
+import os
+import pytest
+from evoagentx.tools.interpreter_docker import DockerInterpreter, DockerLimits
+
+pytestmark = pytest.mark.skipif(os.environ.get("RUN_DOCKER_TESTS") != "true", reason="Docker tests disabled")
+
+def test_memory_limit():
+    limits = DockerLimits(memory="50m", timeout=10)
+    interpreter = DockerInterpreter(runtime="python:3.11", limits=limits, print_stdout=False, print_stderr=False)
+    with pytest.raises(RuntimeError):
+        interpreter.execute("a=[0]*10_000_000", "python")
+

--- a/tests/docker/test_runtime_choice.py
+++ b/tests/docker/test_runtime_choice.py
@@ -1,0 +1,11 @@
+import os
+import pytest
+from evoagentx.tools.interpreter_docker import DockerInterpreter, DockerLimits
+
+pytestmark = pytest.mark.skipif(os.environ.get("RUN_DOCKER_TESTS") != "true", reason="Docker tests disabled")
+
+def test_runtime_choice_node():
+    interpreter = DockerInterpreter(runtime="node:20", limits=DockerLimits(timeout=10), print_stdout=False, print_stderr=False)
+    output = interpreter.execute('console.log(42)', 'node')
+    assert '42' in output
+


### PR DESCRIPTION
## Summary
- add `DockerLimits` dataclass and runtime whitelist
- enforce container resource limits and execution timeout
- allow selecting Python or Node runtimes
- document DockerInterpreter API and defaults
- run docker tests in CI via `RUN_DOCKER_TESTS`
- add docker unit tests

## Testing
- `ruff check evoagentx/tools/interpreter_docker.py tests/docker/test_memory_limit.py tests/docker/test_runtime_choice.py`
- `pytest -q tests/docker/test_memory_limit.py tests/docker/test_runtime_choice.py` *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_68500b33f1548326be57dd4cb612256f