### PR TITLE
Fix Docker OOM detection and test

### DIFF
--- a/docs/api/docker_interpreter.md
+++ b/docs/api/docker_interpreter.md
@@ -26,3 +26,7 @@ Use the `runtime` argument when creating the interpreter. Unsupported values rai
 
 GPU images require a Docker setup with GPU support.
 
+When running on cgroup-v2 systems (e.g. GitHub Actions), Docker only enforces
+`--memory` if `--memory-swap` is also set. The interpreter sets this value equal
+to the memory limit to ensure an OOM kill when the cap is exceeded.
+

--- a/tests/docker/test_memory_limit.py
+++ b/tests/docker/test_memory_limit.py
@@ -5,8 +5,8 @@ from evoagentx.tools.interpreter_docker import DockerInterpreter, DockerLimits
 pytestmark = pytest.mark.skipif(os.environ.get("RUN_DOCKER_TESTS") != "true", reason="Docker tests disabled")
 
 def test_memory_limit():
-    limits = DockerLimits(memory="50m", timeout=10)
-    interpreter = DockerInterpreter(runtime="python:3.11", limits=limits, print_stdout=False, print_stderr=False)
-    with pytest.raises(RuntimeError):
-        interpreter.execute("a=[0]*10_000_000", "python")
+    limits = DockerLimits(memory="128m", timeout=10)
+    code = "a=[0]*25_000_000"  # ~200 MB in CPython
+    with pytest.raises(RuntimeError, match="OOM"):
+        DockerInterpreter(limits=limits, runtime="python:3.11", print_stdout=False, print_stderr=False).run(code)
 


### PR DESCRIPTION
## Summary
- set `memswap_limit` when creating Docker container to enforce hard memory cap
- detect exit code 137 as an out-of-memory kill
- provide simple `run()` helper for Python code
- tighten memory limit test
- document memory-swap requirement for cgroup v2

## Testing
- `pip install -e .[dev]`
- `pip install beautifulsoup4 googlesearch-python wikipedia mcp`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68507a83b3cc83268d74f1542534ad15