### PR TITLE
feat(api): expose runtime & resource limits via CLI and REST

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,17 @@ pnpm dev
 ```
 The `client/` directory contains a full Vite + React + TypeScript project with its own `package.json`.
 
+### DockerInterpreter CLI
+
+Run a snippet in an isolated container:
+
+```bash
+python -m evoagentx.cli run -c "print('hi')"
+python -m evoagentx.cli run --runtime node:20 --memory 512m --cpus 1 --timeout 15 -c "console.log(42)"
+```
+
+The same functionality is exposed via the `/execute` REST endpoint.
+
 
 ## 📚 Acknowledgements 
 This project builds upon several outstanding open-source projects: [AFlow](https://github.com/FoundationAgents/MetaGPT/tree/main/metagpt/ext/aflow), [TextGrad](https://github.com/zou-group/textgrad), [DSPy](https://github.com/stanfordnlp/dspy), [LiveCodeBench](https://github.com/LiveCodeBench/LiveCodeBench), and more. We would like to thank the developers and maintainers of these frameworks for their valuable contributions to the open-source community.

--- a/docs/api/docker_interpreter.md
+++ b/docs/api/docker_interpreter.md
@@ -30,3 +30,26 @@ When running on cgroup-v2 systems (e.g. GitHub Actions), Docker only enforces
 `--memory` if `--memory-swap` is also set. The interpreter sets this value equal
 to the memory limit to ensure an OOM kill when the cap is exceeded.
 
+## CLI Usage
+
+Run snippets directly from the command line:
+
+```bash
+python -m evoagentx.cli run -c "print('hi')"
+python -m evoagentx.cli run --runtime node:20 --memory 512m --cpus 1 --timeout 15 -c "console.log(42)"
+```
+
+## REST API
+
+Send a POST request to `/execute`:
+
+```json
+{
+  "code": "print('hi')",
+  "runtime": "python:3.11",
+  "limits": {"memory": "512m", "cpus": "1.0", "timeout": 20}
+}
+```
+
+The response contains `stdout`, `stderr`, `exit_code` and `runtime_seconds`.
+

--- a/evoagentx/api.py
+++ b/evoagentx/api.py
@@ -1,0 +1,27 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from evoagentx.tools.interpreter_docker import DockerInterpreter, DockerLimits, ALLOWED_RUNTIMES
+
+app = FastAPI()
+
+class ExecRequest(BaseModel):
+    code: str
+    runtime: str = "python:3.11"
+    limits: DockerLimits = DockerLimits()
+
+@app.post("/execute")
+def execute(req: ExecRequest):
+    if req.runtime not in ALLOWED_RUNTIMES:
+        raise HTTPException(status_code=400, detail="Invalid runtime")
+    interpreter = DockerInterpreter(runtime=req.runtime, limits=req.limits, print_stdout=False, print_stderr=False)
+    language = "node" if req.runtime.startswith("node") else "python"
+    try:
+        res = interpreter.execute_verbose(req.code, language)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    return {
+        "stdout": res.stdout,
+        "stderr": res.stderr,
+        "exit_code": res.exit_code,
+        "runtime_seconds": res.runtime_seconds,
+    }

--- a/evoagentx/cli.py
+++ b/evoagentx/cli.py
@@ -1,0 +1,44 @@
+import argparse
+import sys
+from evoagentx.tools.interpreter_docker import (
+    DockerInterpreter,
+    DockerLimits,
+    ALLOWED_RUNTIMES,
+)
+
+
+def _run_code(code: str, runtime: str, limits: DockerLimits):
+    if runtime not in ALLOWED_RUNTIMES:
+        raise ValueError(f"Invalid runtime: {runtime}")
+    interp = DockerInterpreter(runtime=runtime, limits=limits, print_stdout=False, print_stderr=False)
+    lang = "node" if runtime.startswith("node") else "python"
+    res = interp.execute_verbose(code, lang)
+    print(res.stdout, end="")
+    if res.stderr:
+        print(res.stderr, file=sys.stderr, end="")
+    return res.exit_code
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(prog="evoagentx.cli")
+    sub = parser.add_subparsers(dest="command")
+
+    run_p = sub.add_parser("run", help="Execute code in Docker")
+    run_p.add_argument("-c", "--code", required=True, help="Code snippet to run")
+    run_p.add_argument("--runtime", default="python:3.11", help="Runtime to use")
+    run_p.add_argument("--memory", default="512m")
+    run_p.add_argument("--cpus", default="1.0")
+    run_p.add_argument("--pids", type=int, default=64)
+    run_p.add_argument("--timeout", type=int, default=20)
+
+    args = parser.parse_args(argv)
+
+    if args.command == "run":
+        limits = DockerLimits(memory=args.memory, cpus=args.cpus, pids=args.pids, timeout=args.timeout)
+        return _run_code(args.code, args.runtime, limits)
+    parser.print_help()
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    sys.exit(main())

--- a/tests/docker/test_cli_api.py
+++ b/tests/docker/test_cli_api.py
@@ -1,0 +1,23 @@
+import os
+import pytest
+from fastapi.testclient import TestClient
+
+from evoagentx import cli
+from evoagentx.api import app
+from evoagentx.tools.interpreter_docker import DockerLimits
+
+pytestmark = pytest.mark.skipif(os.environ.get("RUN_DOCKER_TESTS") != "true", reason="Docker tests disabled")
+
+
+def test_cli_node(capsys):
+    exit_code = cli.main(["run", "--runtime", "node:20", "--timeout", "10", "-c", "console.log(42)"])
+    captured = capsys.readouterr()
+    assert "42" in captured.out
+    assert exit_code == 0
+
+
+def test_api_execute():
+    client = TestClient(app)
+    resp = client.post("/execute", json={"code": "print('hi')"})
+    assert resp.status_code == 200
+    assert resp.json()["stdout"].strip() == "hi"


### PR DESCRIPTION
## Summary
- extend DockerInterpreter with verbose results and runtime constraints
- expose new `execute_verbose` via CLI and REST API
- document CLI and REST API usage
- add tests for CLI and API

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685089b63fa4832692e9e10f1a3504b9