### PR TITLE
feat(api): expose runtime & resource limits via CLI and REST

### DIFF
--- a/docs/api/docker_interpreter.md
+++ b/docs/api/docker_interpreter.md
@@ -30,3 +30,25 @@ When running on cgroup-v2 systems (e.g. GitHub Actions), Docker only enforces
 `--memory` if `--memory-swap` is also set. The interpreter sets this value equal
 to the memory limit to ensure an OOM kill when the cap is exceeded.
 
+### CLI Example
+
+Run a Node snippet with custom limits:
+
+```bash
+python -m evoagentx.cli run --runtime node:20 --memory 512m --cpus 1 --timeout 15 -c "console.log(42)"
+```
+
+### REST API
+
+POST `/execute` accepts:
+
+```json
+{
+  "code": "print('hi')",
+  "runtime": "python:3.11",
+  "limits": {"memory": "512m", "cpus": "1.0", "timeout": 20}
+}
+```
+
+It returns `stdout`, `stderr`, `exit_code` and `runtime_seconds`.
+

--- a/evoagentx/__main__.py
+++ b/evoagentx/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/evoagentx/cli.py
+++ b/evoagentx/cli.py
@@ -1,0 +1,40 @@
+import argparse
+from .tools.interpreter_docker import DockerInterpreter, DockerLimits, ALLOWED_RUNTIMES
+
+
+def run(code: str, runtime: str = "python:3.11", memory: str | None = None,
+        cpus: str | None = None, pids: int | None = None, timeout: int | None = None) -> str:
+    limits = DockerLimits(
+        memory=memory or DockerLimits.memory,
+        cpus=cpus or DockerLimits.cpus,
+        pids=pids if pids is not None else DockerLimits.pids,
+        timeout=timeout if timeout is not None else DockerLimits.timeout,
+    )
+    interpreter = DockerInterpreter(runtime=runtime, limits=limits, print_stdout=False, print_stderr=False)
+    language = "node" if runtime.startswith("node") else "python"
+    return interpreter.execute(code, language)
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(prog="evoagentx.cli")
+    sub = parser.add_subparsers(dest="command")
+
+    run_p = sub.add_parser("run", help="Execute code in Docker")
+    run_p.add_argument("-c", "--code", required=True)
+    run_p.add_argument("--runtime", default="python:3.11", choices=list(ALLOWED_RUNTIMES.keys()))
+    run_p.add_argument("--memory")
+    run_p.add_argument("--cpus")
+    run_p.add_argument("--pids", type=int)
+    run_p.add_argument("--timeout", type=int)
+
+    args = parser.parse_args(argv)
+
+    if args.command == "run":
+        output = run(args.code, args.runtime, args.memory, args.cpus, args.pids, args.timeout)
+        print(output)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/server/api/__init__.py
+++ b/server/api/__init__.py
@@ -1,4 +1,5 @@
 from .calendar import calendar_router
 from .run import router as run_router
+from .execute import router as exec_router
 
-__all__ = ["calendar_router", "run_router"]
+__all__ = ["calendar_router", "run_router", "exec_router"]

--- a/server/api/execute.py
+++ b/server/api/execute.py
@@ -1,0 +1,14 @@
+from fastapi import APIRouter, HTTPException
+from evoagentx.tools.interpreter_docker import DockerInterpreter, ALLOWED_RUNTIMES
+from server.models.schemas import ExecRequest, ExecResponse
+
+router = APIRouter()
+
+@router.post("/execute", response_model=ExecResponse)
+async def execute(req: ExecRequest):
+    if req.runtime not in ALLOWED_RUNTIMES:
+        raise HTTPException(status_code=400, detail="Unsupported runtime")
+    interpreter = DockerInterpreter(runtime=req.runtime, limits=req.limits, print_stdout=False, print_stderr=False)
+    lang = "node" if req.runtime.startswith("node") else "python"
+    result = interpreter.execute_with_result(req.code, lang)
+    return ExecResponse(**result)

--- a/server/main.py
+++ b/server/main.py
@@ -3,6 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from .api.run import router as run_router
 from .api.calendar import calendar_router
+from .api.execute import router as exec_router
 
 app = FastAPI()
 
@@ -16,6 +17,7 @@ app.add_middleware(
 
 app.include_router(run_router)
 app.include_router(calendar_router)
+app.include_router(exec_router)
 
 if __name__ == "__main__":
     import uvicorn

--- a/server/models/schemas.py
+++ b/server/models/schemas.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from pydantic import BaseModel
-from datetime import datetime
+from evoagentx.tools.interpreter_docker import DockerLimits, ALLOWED_RUNTIMES
 
 
 class RunRequest(BaseModel):
@@ -10,6 +10,29 @@ class RunRequest(BaseModel):
 class RunResponse(BaseModel):
     goal: str
     output: str
+
+
+class ExecRequest(BaseModel):
+    code: str
+    runtime: str = "python:3.11"
+    limits: DockerLimits = DockerLimits()
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{
+                "code": "print('hi')",
+                "runtime": "python:3.11",
+                "limits": {"memory": "512m", "cpus": "1.0", "timeout": 20},
+            }]
+        }
+    }
+
+
+class ExecResponse(BaseModel):
+    stdout: str
+    stderr: str
+    exit_code: int
+    runtime_seconds: float
 
 
 class EventBase(BaseModel):

--- a/tests/docker/test_cli_api.py
+++ b/tests/docker/test_cli_api.py
@@ -1,0 +1,27 @@
+import os
+import pytest
+from fastapi.testclient import TestClient
+from server.main import app
+from evoagentx import cli
+from evoagentx.tools.interpreter_docker import DockerLimits
+
+pytestmark = pytest.mark.skipif(os.environ.get("RUN_DOCKER_TESTS") != "true", reason="Docker tests disabled")
+
+
+def test_cli_run_node():
+    out = cli.run("console.log(42)", runtime="node:20", timeout=10)
+    assert "42" in out
+
+
+def test_execute_endpoint():
+    client = TestClient(app)
+    resp = client.post("/execute", json={"code": "print('hi')", "runtime": "python:3.11"})
+    assert resp.status_code == 200
+    assert resp.json()["stdout"].strip() == "hi"
+    assert resp.json()["exit_code"] == 0
+
+
+def test_invalid_runtime():
+    client = TestClient(app)
+    resp = client.post("/execute", json={"code": "print(1)", "runtime": "ruby:3"})
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- add `evoagentx.cli` with runtime and limit options
- expose `/execute` endpoint in FastAPI server
- implement `execute_with_result` in `DockerInterpreter`
- update API docs for CLI/REST examples
- test CLI and API behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685089b63fa4832692e9e10f1a3504b9