### PR TITLE
Expose runtime controls in CLI & API

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,29 @@ pnpm dev
 ```
 The `client/` directory contains a full Vite + React + TypeScript project with its own `package.json`.
 
+## CLI & REST Examples
+
+Execute code inside Docker directly from the command line:
+
+```bash
+python -m evoagentx.cli run -c "print('hi')"
+python -m evoagentx.cli run --runtime node:20 -c "console.log(42)"
+```
+
+To run as a service:
+
+```bash
+uvicorn evoagentx.api:app --reload
+```
+
+Send a request:
+
+```bash
+curl -X POST http://localhost:8000/execute \
+  -H 'Content-Type: application/json' \
+  -d '{"code":"print(1)"}'
+```
+
 
 ## 📚 Acknowledgements 
 This project builds upon several outstanding open-source projects: [AFlow](https://github.com/FoundationAgents/MetaGPT/tree/main/metagpt/ext/aflow), [TextGrad](https://github.com/zou-group/textgrad), [DSPy](https://github.com/stanfordnlp/dspy), [LiveCodeBench](https://github.com/LiveCodeBench/LiveCodeBench), and more. We would like to thank the developers and maintainers of these frameworks for their valuable contributions to the open-source community.

--- a/docs/api/docker_interpreter.md
+++ b/docs/api/docker_interpreter.md
@@ -30,3 +30,29 @@ When running on cgroup-v2 systems (e.g. GitHub Actions), Docker only enforces
 `--memory` if `--memory-swap` is also set. The interpreter sets this value equal
 to the memory limit to ensure an OOM kill when the cap is exceeded.
 
+### CLI Usage
+
+```bash
+python -m evoagentx.cli run -c "print('hi')"
+python -m evoagentx.cli run --runtime node:20 -c "console.log(42)"
+python -m evoagentx.cli run --memory 256m --cpus 0.5 -c "print('ok')"
+```
+
+### REST API
+
+Start the server:
+
+```bash
+uvicorn evoagentx.api:app --reload
+```
+
+Then POST JSON to `/execute`:
+
+```json
+{
+  "code": "print('hi')",
+  "runtime": "python:3.11",
+  "limits": {"memory": "512m", "cpus": "1.0", "timeout": 20}
+}
+```
+

--- a/evoagentx/api.py
+++ b/evoagentx/api.py
@@ -1,0 +1,27 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from .tools.interpreter_docker import DockerInterpreter, DockerLimits, ALLOWED_RUNTIMES
+
+app = FastAPI()
+
+
+class ExecRequest(BaseModel):
+    code: str
+    runtime: str = "python:3.11"
+    limits: DockerLimits = DockerLimits()
+
+
+@app.post("/execute")
+def execute(req: ExecRequest):
+    if req.runtime not in ALLOWED_RUNTIMES:
+        raise HTTPException(status_code=400, detail="Unsupported runtime")
+    interpreter = DockerInterpreter(
+        runtime=req.runtime,
+        limits=req.limits,
+        print_stdout=False,
+        print_stderr=False,
+    )
+    lang = "node" if req.runtime.startswith("node") else "python"
+    result = interpreter.execute_details(req.code, lang)
+    return result
+

--- a/evoagentx/cli.py
+++ b/evoagentx/cli.py
@@ -1,0 +1,39 @@
+import argparse
+import sys
+from .tools.interpreter_docker import DockerInterpreter, DockerLimits, ALLOWED_RUNTIMES
+
+
+def _determine_language(runtime: str) -> str:
+    if runtime.startswith("node"):
+        return "node"
+    return "python"
+
+
+def run_command(args: argparse.Namespace) -> None:
+    limits = DockerLimits(memory=args.memory, cpus=args.cpus, pids=args.pids, timeout=args.timeout)
+    interpreter = DockerInterpreter(runtime=args.runtime, limits=limits, print_stdout=False, print_stderr=False)
+    lang = _determine_language(args.runtime)
+    result = interpreter.execute_details(args.code, lang)
+    sys.stdout.write(result["stdout"])
+    sys.stderr.write(result["stderr"])
+
+
+def main(argv=None) -> None:
+    parser = argparse.ArgumentParser(prog="evoagentx")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    run_p = sub.add_parser("run", help="Execute code in Docker")
+    run_p.add_argument("-c", "--code", required=True, help="Code snippet to execute")
+    run_p.add_argument("--runtime", default="python:3.11", choices=list(ALLOWED_RUNTIMES.keys()), help="Runtime image")
+    run_p.add_argument("--memory", default="512m")
+    run_p.add_argument("--cpus", default="1.0")
+    run_p.add_argument("--pids", type=int, default=64)
+    run_p.add_argument("--timeout", type=int, default=20)
+    run_p.set_defaults(func=run_command)
+
+    args = parser.parse_args(argv)
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/docker/test_cli_api.py
+++ b/tests/docker/test_cli_api.py
@@ -1,0 +1,33 @@
+import os
+import pytest
+from evoagentx import cli
+from evoagentx.api import app
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.skipif(os.environ.get("RUN_DOCKER_TESTS") != "true", reason="Docker tests disabled")
+
+
+def test_cli_python(capsys):
+    cli.main(["run", "-c", "print('hi')"])
+    captured = capsys.readouterr()
+    assert "hi" in captured.out
+
+
+def test_cli_node(capsys):
+    cli.main(["run", "--runtime", "node:20", "-c", "console.log(42)"])
+    captured = capsys.readouterr()
+    assert "42" in captured.out
+
+
+def test_api_execute():
+    client = TestClient(app)
+    resp = client.post("/execute", json={"code": "print('hi')"})
+    assert resp.status_code == 200
+    assert "hi" in resp.json()["stdout"]
+
+
+def test_api_invalid_runtime():
+    client = TestClient(app)
+    resp = client.post("/execute", json={"code": "print('hi')", "runtime": "ruby"})
+    assert resp.status_code == 400
+


### PR DESCRIPTION
## Summary
- extend `DockerInterpreter` with detailed execution info
- add `evoagentx.cli` to execute code from the command line
- create a minimal FastAPI server exposing `/execute`
- document CLI and API usage
- test CLI and API endpoints

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685089b63fa4832692e9e10f1a3504b9