### PR TITLE
feat(api): expose runtime & limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,22 @@ This installs optional packages such as `python-dotenv`. The
 `run_evoagentx.py` script relies on `load_dotenv()` to read your `.env`
 file, so these dependencies must be installed first.
 
+### CLI Quick Example
+
+You can run small snippets directly in a Docker container using the
+command line interface:
+
+```bash
+python -m evoagentx.cli run -c "print('hi')"
+python -m evoagentx.cli run --runtime node:20 -c "console.log(42)"
+```
+
+Resource limits are configurable:
+
+```bash
+python -m evoagentx.cli run --memory 512m --cpus 1 --timeout 15 -c "print('hi')"
+```
+
 ## LLM Configuration
 
 ### API Key Configuration 

--- a/docs/api/docker_interpreter.md
+++ b/docs/api/docker_interpreter.md
@@ -30,3 +30,24 @@ When running on cgroup-v2 systems (e.g. GitHub Actions), Docker only enforces
 `--memory` if `--memory-swap` is also set. The interpreter sets this value equal
 to the memory limit to ensure an OOM kill when the cap is exceeded.
 
+## CLI Usage
+
+```bash
+python -m evoagentx.cli run -c "print('hi')"
+python -m evoagentx.cli run --runtime node:20 --memory 512m -c "console.log(42)"
+```
+
+## REST API
+
+POST `/execute`
+
+```json
+{
+  "code": "print('hi')",
+  "runtime": "python:3.11",
+  "limits": {"memory": "512m", "cpus": "1.0", "timeout": 20}
+}
+```
+
+Response contains `stdout`, `stderr`, `exit_code` and `runtime_seconds`.
+

--- a/evoagentx/api.py
+++ b/evoagentx/api.py
@@ -1,0 +1,36 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+import time
+
+from .tools.interpreter_docker import DockerInterpreter, DockerLimits, ALLOWED_RUNTIMES
+
+app = FastAPI()
+
+
+class ExecRequest(BaseModel):
+    code: str
+    runtime: str = "python:3.11"
+    limits: DockerLimits = DockerLimits()
+
+
+class ExecResponse(BaseModel):
+    stdout: str
+    stderr: str
+    exit_code: int
+    runtime_seconds: float
+
+
+@app.post("/execute", response_model=ExecResponse)
+def execute(req: ExecRequest):
+    if req.runtime not in ALLOWED_RUNTIMES:
+        raise HTTPException(status_code=400, detail="Invalid runtime")
+
+    interpreter = DockerInterpreter(runtime=req.runtime, limits=req.limits, print_stdout=False, print_stderr=False)
+    language = "node" if req.runtime.startswith("node") else "python"
+    start = time.monotonic()
+    try:
+        output = interpreter.execute(req.code, language)
+        runtime = time.monotonic() - start
+        return ExecResponse(stdout=output, stderr="", exit_code=0, runtime_seconds=runtime)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/evoagentx/cli.py
+++ b/evoagentx/cli.py
@@ -1,0 +1,31 @@
+import argparse
+from .tools.interpreter_docker import DockerInterpreter, DockerLimits, ALLOWED_RUNTIMES
+
+
+def run(argv=None):
+    parser = argparse.ArgumentParser(prog="evoagentx.cli")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    run_parser = subparsers.add_parser("run", help="Execute code in a Docker container")
+    run_parser.add_argument("-c", "--code", required=True, help="Code to execute")
+    run_parser.add_argument("--runtime", default="python:3.11", help="Execution runtime")
+    run_parser.add_argument("--memory", default="512m", help="Memory limit")
+    run_parser.add_argument("--cpus", default="1.0", help="CPU limit")
+    run_parser.add_argument("--pids", default=64, type=int, help="PID limit")
+    run_parser.add_argument("--timeout", default=20, type=int, help="Execution timeout")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "run":
+        if args.runtime not in ALLOWED_RUNTIMES:
+            raise ValueError(f"Invalid runtime '{args.runtime}'. Allowed: {list(ALLOWED_RUNTIMES)}")
+        limits = DockerLimits(memory=args.memory, cpus=args.cpus, pids=args.pids, timeout=args.timeout)
+        interpreter = DockerInterpreter(runtime=args.runtime, limits=limits, print_stdout=False, print_stderr=False)
+        language = "node" if args.runtime.startswith("node") else "python"
+        output = interpreter.execute(args.code, language)
+        print(output)
+        return output
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/docker/test_api_execute.py
+++ b/tests/docker/test_api_execute.py
@@ -1,0 +1,18 @@
+import os
+import pytest
+from fastapi.testclient import TestClient
+from evoagentx.api import app
+
+pytestmark = pytest.mark.skipif(os.environ.get("RUN_DOCKER_TESTS") != "true", reason="Docker tests disabled")
+
+client = TestClient(app)
+
+def test_execute_python():
+    res = client.post("/execute", json={"code": "print('hi')"})
+    assert res.status_code == 200
+    assert "hi" in res.json()["stdout"]
+
+
+def test_execute_invalid_runtime():
+    res = client.post("/execute", json={"code": "print('hi')", "runtime": "bad"})
+    assert res.status_code == 400

--- a/tests/docker/test_cli.py
+++ b/tests/docker/test_cli.py
@@ -1,0 +1,13 @@
+import os
+import pytest
+from evoagentx import cli
+
+pytestmark = pytest.mark.skipif(os.environ.get("RUN_DOCKER_TESTS") != "true", reason="Docker tests disabled")
+
+def test_cli_run_python(capsys):
+    out = cli.run(["run", "-c", "print('hi')"])
+    assert "hi" in out
+
+def test_cli_run_node(capsys):
+    out = cli.run(["run", "--runtime", "node:20", "-c", "console.log(42)"])
+    assert "42" in out


### PR DESCRIPTION
## Summary
- add CLI for Docker interpreter with runtime & resource limit options
- expose `/execute` REST endpoint that accepts runtime and limits
- document CLI usage and REST schema
- test CLI and API integration

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685089b63fa4832692e9e10f1a3504b9