### PR TITLE
Add intelligence-parser docs and update setup

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -96,6 +96,10 @@ pip install -e .
 ```
 </details>
 
+`intelligence-parser/` 文件夹包含独立的 TypeScript 包，用于解析对话信息。
+进入这个目录，运行 `npm install` 安装依赖，然后使用 `npm test` 运行测试。
+
+
 ## LLM配置
 
 ### API密钥配置 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ pip install -e .
 ```
 </details>
 
+The `intelligence-parser/` folder contains a standalone TypeScript package for parsing chat messages.
+Run `npm install` inside that directory to install its dependencies and `npm test` to execute the tests.
+
+
 ## Setup
 
 Before running any scripts or examples, install the project dependencies:

--- a/docs/development.md
+++ b/docs/development.md
@@ -23,6 +23,12 @@ pip install -e .[dev]
 pip install -r requirements.txt
 ```
 
+Install the Node dependencies for the intelligence-parser package:
+```bash
+cd intelligence-parser
+npm install
+```
+
 Set your `OPENAI_API_KEY` as described in the [Quickstart Guide](quickstart.md#api-key--llm-setup).
 
 ## Running Tests

--- a/intelligence-parser/README.md
+++ b/intelligence-parser/README.md
@@ -1,0 +1,15 @@
+# Intelligence Parser
+
+This directory contains a standalone TypeScript utility that parses chat history and user input into structured JSON.
+
+## Install
+
+```bash
+npm install
+```
+
+## Running Tests
+
+```bash
+npm test
+```


### PR DESCRIPTION
## Summary
- document standalone intelligence-parser package
- reference the parser in README and README-zh
- document Node setup step in development guide

## Testing
- `pytest -q` *(fails: FileNotFoundError)*
- `npm install && npm test` in `intelligence-parser`

------
https://chatgpt.com/codex/tasks/task_e_685091b1b55c83269b0c05b17b21bf26