### PR TITLE
Implement Tool input verification

### DIFF
--- a/tests/test_prompt_template_tools.py
+++ b/tests/test_prompt_template_tools.py
@@ -1,0 +1,46 @@
+import pytest
+from evoagentx.prompts.template import PromptTemplate
+from evoagentx.tools.tool import Tool
+from typing import List, Dict, Any, Callable
+
+class SimpleTool(Tool):
+    name: str = "simple"
+
+    def get_tools(self) -> List[Callable]:
+        return [self.do]
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        return []
+
+    def do(self):
+        pass
+
+    def get_tool_descriptions(self) -> List[str]:
+        return ["simple description"]
+
+class BadTool(SimpleTool):
+    name: str = "bad"
+    def get_tools(self) -> List[Callable]:
+        return [self.do, self.other]
+
+    def other(self):
+        pass
+
+    def get_tool_descriptions(self) -> List[str]:
+        return ["only one"]
+
+def test_render_tools_with_strings():
+    tmpl = PromptTemplate(instruction="instr", tools=["a", "b"])
+    rendered = tmpl.render_tools()
+    assert "- a" in rendered
+    assert "- b" in rendered
+
+def test_render_tools_with_objects():
+    tmpl = PromptTemplate(instruction="instr", tools=[SimpleTool()])
+    rendered = tmpl.render_tools()
+    assert "simple description" in rendered
+
+def test_render_tools_mismatch():
+    tmpl = PromptTemplate(instruction="instr", tools=[BadTool()])
+    with pytest.raises(ValueError):
+        tmpl.render_tools()


### PR DESCRIPTION
## Summary
- accept tool objects or strings in prompts
- verify tool descriptions match available functions
- ensure invalid tool lists raise errors
- test PromptTemplate tool handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68509958f7848326afe5287cc91c6d00