### PR TITLE
Validate action graphs before optimizer snapshot

### DIFF
--- a/evoagentx/optimizers/sew_optimizer.py
+++ b/evoagentx/optimizers/sew_optimizer.py
@@ -778,7 +778,10 @@ class SEWOptimizer(BaseOptimizer, RegistryOptimizer):
         if isinstance(graph, SequentialWorkFlowGraph):
             graph_info = graph.get_graph_info()
         elif isinstance(graph, ActionGraph):
-            # TODO check if the action graph is valid 
+            try:
+                graph.validate()
+            except ValueError as e:
+                raise ValueError(f"Invalid ActionGraph: {e}") from e
             graph_info = graph
         else:
             raise ValueError(f"Invalid graph type: {type(graph)}. The graph should be an instance of `SequentialWorkFlowGraph` or `ActionGraph`.")
@@ -801,8 +804,11 @@ class SEWOptimizer(BaseOptimizer, RegistryOptimizer):
         if isinstance(self.graph, SequentialWorkFlowGraph):
             graph = SequentialWorkFlowGraph.from_dict(self._snapshot[best_index]["graph"])
         elif isinstance(self.graph, ActionGraph):
-            # TODO check if the action graph is valid
             graph = self._snapshot[best_index]["graph"]
+            try:
+                graph.validate()
+            except ValueError as e:
+                raise ValueError(f"Invalid ActionGraph in snapshot: {e}") from e
         else:
             raise ValueError(f"Invalid graph type: {type(self.graph)}. The graph should be an instance of `SequentialWorkFlowGraph` or `ActionGraph`.")
         

--- a/evoagentx/workflow/action_graph.py
+++ b/evoagentx/workflow/action_graph.py
@@ -55,6 +55,41 @@ class ActionGraph(BaseModule):
             }
         }
         return config
+
+    def validate(self):
+        """Validate required fields and operators structure."""
+        missing_fields = []
+        if not getattr(self, "name", None):
+            missing_fields.append("name")
+        if not getattr(self, "description", None):
+            missing_fields.append("description")
+        if not getattr(self, "llm_config", None):
+            missing_fields.append("llm_config")
+        if missing_fields:
+            raise ValueError(f"ActionGraph is missing required fields: {missing_fields}")
+
+        operators = {}
+        for extra_name, extra_value in self.__pydantic_extra__.items():
+            if isinstance(extra_value, Operator):
+                operators[extra_name] = extra_value
+
+        if not operators:
+            raise ValueError("ActionGraph must contain at least one Operator")
+
+        for op_name, op in operators.items():
+            op_missing = []
+            if not getattr(op, "name", None):
+                op_missing.append("name")
+            if not getattr(op, "description", None):
+                op_missing.append("description")
+            if getattr(op, "interface", None) is None:
+                op_missing.append("interface")
+            if getattr(op, "prompt", None) is None:
+                op_missing.append("prompt")
+            if op_missing:
+                raise ValueError(f"Operator '{op_name}' is missing fields: {op_missing}")
+
+        return True
     
     @classmethod
     def load_module(cls, path: str, llm_config: LLMConfig = None, **kwargs) -> Dict:

--- a/tests/src/optimizers/test_sew_optimizer_validation.py
+++ b/tests/src/optimizers/test_sew_optimizer_validation.py
@@ -1,0 +1,38 @@
+import unittest
+from unittest.mock import Mock
+
+from evoagentx.models import OpenAILLMConfig
+from evoagentx.workflow.action_graph import ActionGraph
+from evoagentx.optimizers.sew_optimizer import SEWOptimizer
+from evoagentx.evaluators.evaluator import Evaluator
+
+
+class InvalidActionGraph(ActionGraph):
+    """ActionGraph without any operators for validation testing."""
+
+    def __init__(self, llm_config: OpenAILLMConfig, **kwargs):
+        super().__init__(name="Invalid", description="Invalid", llm_config=llm_config, **kwargs)
+        # no operators defined
+
+
+class TestSEWOptimizerValidation(unittest.TestCase):
+    def setUp(self):
+        self.llm_config = OpenAILLMConfig(model="gpt-4o-mini", openai_key="XXX")
+        self.llm = Mock()
+        self.evaluator = Evaluator(llm=self.llm)
+        self.invalid_graph = InvalidActionGraph(llm_config=self.llm_config)
+
+    def test_log_snapshot_with_invalid_graph(self):
+        optimizer = SEWOptimizer(graph=self.invalid_graph, evaluator=self.evaluator, llm=self.llm, optimize_mode="prompt")
+        with self.assertRaises(ValueError):
+            optimizer.log_snapshot(self.invalid_graph, metrics={"score": 0})
+
+    def test_select_graph_with_invalid_snapshot(self):
+        optimizer = SEWOptimizer(graph=self.invalid_graph, evaluator=self.evaluator, llm=self.llm, optimize_mode="prompt")
+        optimizer._snapshot.append({"index": 0, "graph": self.invalid_graph, "metrics": {"score": 1}})
+        with self.assertRaises(ValueError):
+            optimizer._select_graph_with_highest_score()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `ActionGraph.validate` to verify required fields and operators
- check action graphs in `SEWOptimizer.log_snapshot` and `_select_graph_with_highest_score`
- raise informative errors when invalid graphs are encountered
- test optimizer validation with invalid action graphs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68509b524aac8326b0027eb1128f1231