### PR TITLE
Improve action tool serialization

### DIFF
--- a/tests/src/core/test_action_serialization.py
+++ b/tests/src/core/test_action_serialization.py
@@ -1,0 +1,29 @@
+import unittest
+from evoagentx.actions.action import Action
+from evoagentx.tools.tool import Tool
+
+class DummyTool(Tool):
+    name: str = "dummy"
+    def get_tools(self):
+        return [self.do]
+    def get_tool_schemas(self):
+        return []
+    def do(self):
+        return "done"
+    def get_tool_descriptions(self):
+        return ["dummy"]
+
+class DummyAction(Action):
+    def execute(self, llm=None, inputs=None, sys_msg=None, return_prompt=False, **kwargs):
+        return {}
+
+class TestActionSerialization(unittest.TestCase):
+    def test_tool_roundtrip(self):
+        action = DummyAction(name="a", description="b", tools=[DummyTool()])
+        data = action.to_dict()
+        loaded = DummyAction.from_dict(data)
+        self.assertIsInstance(loaded.tools[0], DummyTool)
+        self.assertEqual(loaded.tools[0].name, "dummy")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- serialize tools with module path and config
- rebuild tools when loading actions
- test round-trip serialization for actions with tools

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68509d826adc8326828ddd8e7554739a