### PR TITLE
Improve agent long-term memory initialization

### DIFF
--- a/evoagentx/agents/agent.py
+++ b/evoagentx/agents/agent.py
@@ -12,6 +12,7 @@ from ..models.base_model import BaseLLM
 from ..memory.memory import ShortTermMemory
 from ..memory.long_term_memory import LongTermMemory
 from ..memory.memory_manager import MemoryManager
+from ..memory.utils import create_long_term_memory, create_memory_manager
 from ..storages.base import StorageHandler
 from ..actions.action import Action
 from ..actions.action import ContextExtraction
@@ -296,14 +297,16 @@ class Agent(BaseModule):
         Initialize long-term memory components.
         """
         assert self.storage_handler is not None, "must provide ``storage_handler`` when use_long_term_memory=True"
-        # TODO revise the initialisation of long_term_memory and long_term_memory_manager
-        if not self.long_term_memory:
-            self.long_term_memory = LongTermMemory()
-        if not self.long_term_memory_manager:
-            self.long_term_memory_manager = MemoryManager(
-                storage_handler=self.storage_handler,
-                memory=self.long_term_memory
-            )
+
+        self.long_term_memory = create_long_term_memory(
+            storage_handler=self.storage_handler,
+            memory=self.long_term_memory,
+        )
+        self.long_term_memory_manager = create_memory_manager(
+            storage_handler=self.storage_handler,
+            memory_manager=self.long_term_memory_manager,
+            memory=self.long_term_memory,
+        )
     
     def init_context_extractor(self):
         """

--- a/evoagentx/memory/__init__.py
+++ b/evoagentx/memory/__init__.py
@@ -4,8 +4,8 @@ from .memory_manager import MemoryManager
 from .memory_object import MemoryObject
 from .store import MemoryStore
 from .sqlite_store import SQLiteStore
-
 from .redis_store import RedisStore
+from .utils import create_long_term_memory, create_memory_manager
 __all__ = [
     "BaseMemory",
     "ShortTermMemory",
@@ -15,4 +15,6 @@ __all__ = [
     "MemoryStore",
     "SQLiteStore",
     "RedisStore",
+    "create_long_term_memory",
+    "create_memory_manager",
 ]

--- a/evoagentx/memory/utils.py
+++ b/evoagentx/memory/utils.py
@@ -1,0 +1,62 @@
+"""Helper utilities for memory initialization."""
+
+from typing import Optional, Union, Dict, Any
+
+from .long_term_memory import LongTermMemory
+from .memory_manager import MemoryManager
+from ..storages.base import StorageHandler
+
+
+def create_long_term_memory(
+    storage_handler: StorageHandler,
+    memory: Optional[Union[LongTermMemory, Dict[str, Any]]] = None,
+) -> LongTermMemory:
+    """Return a ``LongTermMemory`` instance bound to ``storage_handler``.
+
+    If ``memory`` is ``None`` a new instance will be created. If ``memory`` is a
+    dictionary it will be used to construct the object. Existing instances will
+    be returned unchanged, except that their ``storage`` attribute is populated
+    when missing.
+    """
+    if memory is None:
+        return LongTermMemory(storage=storage_handler)
+    if isinstance(memory, dict):
+        memory.setdefault("storage", storage_handler)
+        return LongTermMemory(**memory)
+    if getattr(memory, "storage", None) is None:
+        memory.storage = storage_handler
+    return memory
+
+
+def create_memory_manager(
+    storage_handler: StorageHandler,
+    memory_manager: Optional[Union[MemoryManager, Dict[str, Any]]] = None,
+    memory: Optional[Union[LongTermMemory, Dict[str, Any]]] = None,
+) -> MemoryManager:
+    """Return a ``MemoryManager`` instance bound to ``storage_handler``.
+
+    ``memory_manager`` and ``memory`` may be provided as instances or dictionaries.
+    Existing objects are reused and never replaced.
+    """
+    if isinstance(memory_manager, dict):
+        memory_manager.setdefault("storage_handler", storage_handler)
+        if "memory" in memory_manager:
+            mm_memory = create_long_term_memory(storage_handler, memory_manager["memory"])
+        else:
+            mm_memory = create_long_term_memory(storage_handler, memory)
+        memory_manager["memory"] = mm_memory
+        return MemoryManager(**memory_manager)
+
+    if memory_manager is None:
+        mm_memory = create_long_term_memory(storage_handler, memory)
+        return MemoryManager(storage_handler=storage_handler, memory=mm_memory)
+
+    # existing manager instance
+    if getattr(memory_manager, "storage_handler", None) is None:
+        memory_manager.storage_handler = storage_handler
+    if getattr(memory_manager, "memory", None) is None:
+        memory_manager.memory = create_long_term_memory(storage_handler, memory)
+    else:
+        memory_manager.memory = create_long_term_memory(storage_handler, memory_manager.memory)
+    return memory_manager
+

--- a/tests/src/agents/test_agent_long_term_memory.py
+++ b/tests/src/agents/test_agent_long_term_memory.py
@@ -1,0 +1,82 @@
+import unittest
+
+from evoagentx.agents.agent import Agent
+from evoagentx.models.model_configs import LiteLLMConfig
+from evoagentx.memory import LongTermMemory, MemoryManager
+from evoagentx.storages.base import StorageHandler
+from evoagentx.storages.storages_config import StoreConfig, DBConfig
+
+
+class TestAgentLongTermMemory(unittest.TestCase):
+    def _storage(self):
+        db_cfg = DBConfig(db_name="sqlite", path=":memory:")
+        return StorageHandler(storageConfig=StoreConfig(dbConfig=db_cfg))
+
+    def _llm_cfg(self):
+        return LiteLLMConfig(model="gpt-4o-mini", openai_key="xxxxx")
+
+    def test_enable_on_init(self):
+        storage = self._storage()
+        agent = Agent(
+            name="a1",
+            description="test",
+            llm_config=self._llm_cfg(),
+            storage_handler=storage,
+            use_long_term_memory=True,
+        )
+        self.assertIsNotNone(agent.long_term_memory)
+        self.assertIsNotNone(agent.long_term_memory_manager)
+        self.assertIs(agent.long_term_memory_manager.memory, agent.long_term_memory)
+        self.assertIs(agent.long_term_memory_manager.storage_handler, storage)
+
+    def test_enable_later(self):
+        storage = self._storage()
+        agent = Agent(
+            name="a2",
+            description="test",
+            llm_config=self._llm_cfg(),
+            storage_handler=storage,
+        )
+        self.assertIsNone(agent.long_term_memory)
+        agent.use_long_term_memory = True
+        agent.init_long_term_memory()
+        self.assertIsNotNone(agent.long_term_memory)
+        self.assertIsNotNone(agent.long_term_memory_manager)
+
+    def test_preserve_instances(self):
+        storage = self._storage()
+        mem = LongTermMemory(storage=storage)
+        mgr = MemoryManager(storage_handler=storage, memory=mem)
+        agent = Agent(
+            name="a3",
+            description="test",
+            llm_config=self._llm_cfg(),
+            storage_handler=storage,
+            use_long_term_memory=True,
+            long_term_memory=mem,
+            long_term_memory_manager=mgr,
+        )
+        self.assertIs(agent.long_term_memory, mem)
+        self.assertIs(agent.long_term_memory_manager, mgr)
+        # re-init should not replace
+        agent.init_long_term_memory()
+        self.assertIs(agent.long_term_memory, mem)
+        self.assertIs(agent.long_term_memory_manager, mgr)
+
+    def test_existing_memory_no_manager(self):
+        storage = self._storage()
+        mem = LongTermMemory(storage=storage)
+        agent = Agent(
+            name="a4",
+            description="test",
+            llm_config=self._llm_cfg(),
+            storage_handler=storage,
+            use_long_term_memory=True,
+            long_term_memory=mem,
+        )
+        self.assertIs(agent.long_term_memory_manager.memory, mem)
+        self.assertIs(agent.long_term_memory_manager.storage_handler, storage)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add helper functions for long-term memory creation
- use helpers in `Agent.init_long_term_memory`
- expose helpers from memory package
- test enabling/disabling long-term memory

## Testing
- `pip install -e .[dev]`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850c8ae63a48326904caecdcb76ed9b