### PR TITLE
Integrate macOS calendar hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,9 @@ pip install -r server/requirements.txt
 uvicorn server.main:app --reload
 ```
 
+The optional calendar API integrates with macOS Calendar via `osascript`. These
+endpoints only work when run on macOS with AppleScript available.
+
 3. For the React frontend:
 
 ```bash

--- a/server/core/macos_calendar.py
+++ b/server/core/macos_calendar.py
@@ -6,7 +6,6 @@ If the host isn’t macOS, calls just raise NotImplementedError for now.
 from __future__ import annotations
 
 import datetime as _dt
-import json
 import platform
 import subprocess
 from typing import TypedDict
@@ -20,9 +19,11 @@ class CalendarEvent(TypedDict):
     calendar: str        # e.g. "Home", "Work"
 
 
-def _run_applescript(script: str) -> None:
+def _run_applescript(script: str) -> str:
+    """Execute an AppleScript snippet and return its stdout."""
+
     try:
-        subprocess.run(
+        result = subprocess.run(
             ["osascript", "-e", script],
             check=True,
             capture_output=True,
@@ -30,6 +31,8 @@ def _run_applescript(script: str) -> None:
         )
     except subprocess.CalledProcessError as exc:
         raise RuntimeError(exc.stderr or exc.stdout) from exc
+
+    return result.stdout.strip()
 
 
 def _assert_macos() -> None:
@@ -41,8 +44,11 @@ def _assert_macos() -> None:
 # PUBLIC API
 # ────────────────────────────────────────────────────────
 
-def create_calendar_event(evt: CalendarEvent) -> None:
-    """Drop an event into the user’s default Calendar collection."""
+def create_calendar_event(evt: CalendarEvent) -> str:
+    """Drop an event into the user’s default Calendar collection.
+
+    Returns the created event's UID.
+    """
 
     _assert_macos()
 
@@ -64,17 +70,52 @@ def create_calendar_event(evt: CalendarEvent) -> None:
             make new calendar with properties {{name:calName}}
         end if
         set targetCal to calendar calName
-        make new event at end of events of targetCal with properties ¬
+        set newEvent to make new event at end of events of targetCal with properties ¬
             {{summary:theSummary, description:theDescription, start date:theStartDate, end date:theEndDate}}
+        return uid of newEvent
+    end tell
+    '''
+    return _run_applescript(script)
+
+
+def update_calendar_event(event_uid: str, evt: CalendarEvent) -> None:  # noqa: D401
+    """Update an existing event identified by ``event_uid``."""
+
+    _assert_macos()
+
+    start_iso = evt["start"].strftime("%Y-%m-%d %H:%M:%S")
+    end_iso = evt["end"].strftime("%Y-%m-%d %H:%M:%S")
+    notes = evt["notes"] or ""
+
+    script = f'''
+    set eventId to "{event_uid}"
+    set theSummary to "{evt["title"]}"
+    set theDescription to "{notes}"
+    set theStartDate to date "{start_iso}"
+    set theEndDate to date "{end_iso}"
+
+    tell application "Calendar"
+        set targetEvent to first event of calendars whose uid is eventId
+        set summary of targetEvent to theSummary
+        set description of targetEvent to theDescription
+        set start date of targetEvent to theStartDate
+        set end date of targetEvent to theEndDate
     end tell
     '''
     _run_applescript(script)
 
 
-# stubbed helpers you might add later
 def delete_calendar_event(event_uid: str) -> None:  # noqa: D401
-    """Remove an event by its Calendar UID (not yet wired)."""
-    raise NotImplementedError
+    """Remove an event by its Calendar UID."""
+
+    _assert_macos()
+
+    script = f'''
+    tell application "Calendar"
+        delete (every event of calendars whose uid is "{event_uid}")
+    end tell
+    '''
+    _run_applescript(script)
 
 
 def list_calendar_events(from_: _dt.datetime, to_: _dt.datetime) -> list[dict]:


### PR DESCRIPTION
## Summary
- connect event update & delete routes to macOS helper functions
- support returning calendar UID when creating events
- add helper functions for updating/deleting events via AppleScript
- note optional macOS requirement in README

## Testing
- `ruff check server/api/calendar.py server/core/macos_calendar.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851270b43bc83269aa1ff3e2a5bdba9