### PR TITLE
Fix ruff F841 in HotPotQA test

### DIFF
--- a/tests/src/benchmark/test_hotpotqa.py
+++ b/tests/src/benchmark/test_hotpotqa.py
@@ -144,8 +144,8 @@ class TestAFlowHotPotQA(unittest.TestCase):
             for item in self.sample_data:
                 f.write(json.dumps(item) + '\n')
 
-        benchmark = AFlowHotPotQA(path=self.temp_dir, mode="test")
-        
+        AFlowHotPotQA(path=self.temp_dir, mode="test")
+
         # Test data loading
         self.assertEqual(mock_download.call_count, 0)
 


### PR DESCRIPTION
## Summary
- remove unused `benchmark` variable from `test_hotpotqa.py`

## Testing
- `ruff check tests/src/benchmark/test_hotpotqa.py`

------
https://chatgpt.com/codex/tasks/task_e_685129ac2fb883269360a39a1de2c312