### PR TITLE
Remove unused import in example

### DIFF
--- a/examples/agent_with_multiple_actions.py
+++ b/examples/agent_with_multiple_actions.py
@@ -5,7 +5,6 @@ from dotenv import load_dotenv
 from typing import Optional
 from evoagentx.models import BaseLLM, OpenAILLMConfig
 from evoagentx.agents import Agent
-from evoagentx.core.module_utils import extract_code_blocks
 from evoagentx.actions import Action, ActionInput, ActionOutput
 
 load_dotenv()


### PR DESCRIPTION
## Summary
- drop unused `extract_code_blocks` import in `agent_with_multiple_actions`

## Testing
- `ruff check examples/agent_with_multiple_actions.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851297c3424832690310140cc649c0e