### PR TITLE
Fix F541 lint in workflow demo

### DIFF
--- a/examples/workflow_demo.py
+++ b/examples/workflow_demo.py
@@ -77,9 +77,9 @@ def main():
         print(f"\nMain file: {results.main_file}")
         file_type = os.path.splitext(results.main_file)[1].lower()
         if file_type == '.html':
-            print(f"You can open this HTML file in a browser to play the Tetris game")
+            print("You can open this HTML file in a browser to play the Tetris game")
         else:
-            print(f"This is the main entry point for your application")
+            print("This is the main entry point for your application")
     
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- fix ruff F541 warning in `workflow_demo.py`

## Testing
- `ruff check examples/workflow_demo.py`
- `pytest -q` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_6851298705c88326bc65eabaf325bbda