### PR TITLE
Remove dead import

### DIFF
--- a/server/core/macos_calendar.py
+++ b/server/core/macos_calendar.py
@@ -6,7 +6,6 @@ If the host isn’t macOS, calls just raise NotImplementedError for now.
 from __future__ import annotations
 
 import datetime as _dt
-import json
 import platform
 import subprocess
 from typing import TypedDict


### PR DESCRIPTION
## Summary
- delete unused `json` import in macOS calendar helper

## Testing
- `ruff check server/core/macos_calendar.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68512999e08c832693da56697678b532