### PR TITLE
Fix duplicate datetime import in schemas

### DIFF
--- a/server/models/schemas.py
+++ b/server/models/schemas.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 from pydantic import BaseModel
-from datetime import datetime
 
 
 class RunRequest(BaseModel):


### PR DESCRIPTION
## Summary
- remove duplicate import from `server/models/schemas.py`

## Testing
- `ruff check server/models/schemas.py`
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685129a82ab08326b84b59acbfaacff8