### PR TITLE
Clean up server utilities

### DIFF
--- a/server/core/agent_runner.py
+++ b/server/core/agent_runner.py
@@ -1,3 +1,0 @@
-from evoagentx.core.runner import run_workflow_async
-
-

--- a/server/core/macos_calendar.py
+++ b/server/core/macos_calendar.py
@@ -6,7 +6,6 @@ If the host isn’t macOS, calls just raise NotImplementedError for now.
 from __future__ import annotations
 
 import datetime as _dt
-import json
 import platform
 import subprocess
 from typing import TypedDict


### PR DESCRIPTION
## Summary
- remove unused agent_runner helper
- drop unused json import from macOS calendar wrapper

## Testing
- `ruff check server/core`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851299397648326973c2c9b322cf4e5