### PR TITLE
Fix unused imports in LCB test

### DIFF
--- a/tests/src/benchmark/test_livecodebench.py
+++ b/tests/src/benchmark/test_livecodebench.py
@@ -1,9 +1,6 @@
 import unittest
 from unittest.mock import patch
-import os
-import shutil
-import tempfile
-from datasets import load_from_disk 
+from datasets import load_from_disk
 from evoagentx.benchmark.livecodebench import LiveCodeBench
 from evoagentx.benchmark.lcb_utils.code_generation import CodeGenerationProblem
 from evoagentx.benchmark.lcb_utils.test_output_prediction import TestOutputPredictionProblem


### PR DESCRIPTION
## Summary
- clean up unused imports in `test_livecodebench`
- verify with `ruff` that F401 warnings are gone

## Testing
- `pytest -q`
- `ruff check tests/src/benchmark/test_livecodebench.py --select F401`


------
https://chatgpt.com/codex/tasks/task_e_685129aed1f08326b6be4f8df7f57007