### PR TITLE
Fix string interpolation in tests

### DIFF
--- a/tests/src/core/test_module.py
+++ b/tests/src/core/test_module.py
@@ -40,7 +40,7 @@ class ToyModule2(BaseModule):
             if self.k4 is not None and self.k5 is not None:
                 self.k6 = ToyTool(self.k4, self.k5)
             else:
-                raise ValueError(f"either k4 and k5 is None!")
+                raise ValueError("either k4 and k5 is None!")
 
 class ToyModule2SubClass(ToyModule2):
 


### PR DESCRIPTION
## Summary
- remove f-string interpolation in test
- run ruff on affected file

## Testing
- `ruff check tests/src/core/test_module.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685129be04588326868a733cab303c0f