### PR TITLE
Fix unused cast import

### DIFF
--- a/tests/test_utils_extra.py
+++ b/tests/test_utils_extra.py
@@ -9,7 +9,6 @@ from evoagentx.storages.storages_config import (
 )
 from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
-from typing import cast
 from evoagentx.utils import factory
 from evoagentx.utils import calendar as cal
 warnings.filterwarnings("ignore", "`timeout`", DeprecationWarning)


### PR DESCRIPTION
## Summary
- clean up test_utils_extra by dropping an unused `cast` import

## Testing
- `ruff check tests/test_utils_extra.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685129cd14b08326a800da41f06d69c4