### PR TITLE
Add websocket progress updates

### DIFF
--- a/client/src/components/OutputPanel.tsx
+++ b/client/src/components/OutputPanel.tsx
@@ -1,10 +1,16 @@
 import type { FC } from 'react';
 
-interface Props { output: string }
-const OutputPanel: FC<Props> = ({ output }) => (
-  <div className="mt-6 rounded-xl border p-4 bg-gray-50 whitespace-pre-line">
-    {output || <span className="text-gray-400">No output yet.</span>}
-  </div>
-);
+interface Props {
+  output: string;
+  progress: string[];
+}
+const OutputPanel: FC<Props> = ({ output, progress }) => {
+  const text = [...progress, output].filter(Boolean).join('\n');
+  return (
+    <div className="mt-6 rounded-xl border p-4 bg-gray-50 whitespace-pre-line">
+      {text || <span className="text-gray-400">No output yet.</span>}
+    </div>
+  );
+};
 
 export default OutputPanel;

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -1,16 +1,24 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import GoalInput from '../components/GoalInput';
 import OutputPanel from '../components/OutputPanel';
 import Loader from '../components/Loader';
 
 export default function Dashboard() {
   const [output, setOutput] = useState('');
+  const [progress, setProgress] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+
+  useEffect(() => {
+    const ws = new WebSocket('ws://localhost:8000/ws');
+    ws.onmessage = ev => setProgress(prev => [...prev, ev.data]);
+    return () => ws.close();
+  }, []);
 
   const run = async (goal: string) => {
     setLoading(true);
     setError('');
+    setProgress([]);
     try {
       const res = await fetch('http://localhost:8000/run', {
         method: 'POST',
@@ -31,10 +39,9 @@ export default function Dashboard() {
     <div style={{ padding: '1rem' }}>
       <h1>EvoAgentX</h1>
       <GoalInput onRun={run} loading={loading} />
-      <OutputPanel output={output} />
+      <OutputPanel output={output} progress={progress} />
       {loading && <Loader />}
       {error && <p className="text-red-600 mt-2">{error}</p>}
-      <pre>{output}</pre>
     </div>
   );
 }

--- a/server/api/run.py
+++ b/server/api/run.py
@@ -1,13 +1,14 @@
 from fastapi import APIRouter, HTTPException
 from server.models.schemas import RunRequest, RunResponse
 from evoagentx.core.runner import run_workflow_async
+from server.core.websocket_manager import manager
 
 router = APIRouter()
 
 @router.post("/run", response_model=RunResponse)
 async def run(request: RunRequest):
     try:
-        output = await run_workflow_async(request.goal)
+        output = await run_workflow_async(request.goal, progress_cb=manager.broadcast)
     except ValueError as e:
         # < 10 characters or other validation errors
         raise HTTPException(status_code=400, detail=str(e))

--- a/server/core/websocket_manager.py
+++ b/server/core/websocket_manager.py
@@ -1,0 +1,23 @@
+from typing import List
+from fastapi import WebSocket
+
+class ConnectionManager:
+    def __init__(self) -> None:
+        self.active_connections: List[WebSocket] = []
+
+    async def connect(self, websocket: WebSocket) -> None:
+        await websocket.accept()
+        self.active_connections.append(websocket)
+
+    def disconnect(self, websocket: WebSocket) -> None:
+        if websocket in self.active_connections:
+            self.active_connections.remove(websocket)
+
+    async def broadcast(self, message: str) -> None:
+        for connection in list(self.active_connections):
+            try:
+                await connection.send_text(message)
+            except Exception:
+                self.disconnect(connection)
+
+manager = ConnectionManager()

--- a/server/main.py
+++ b/server/main.py
@@ -1,8 +1,9 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 
 from .api.run import router as run_router
 from .api.calendar import calendar_router
+from .core.websocket_manager import manager
 
 app = FastAPI()
 
@@ -16,6 +17,16 @@ app.add_middleware(
 
 app.include_router(run_router)
 app.include_router(calendar_router)
+
+
+@app.websocket("/ws")
+async def websocket_endpoint(websocket: WebSocket):
+    await manager.connect(websocket)
+    try:
+        while True:
+            await websocket.receive_text()
+    except WebSocketDisconnect:
+        manager.disconnect(websocket)
 
 if __name__ == "__main__":
     import uvicorn


### PR DESCRIPTION
## Summary
- broadcast run progress via `/ws` websocket
- allow runner to report progress through a callback
- show progress output live in Dashboard UI

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68513185d37483269d2ac50894223968