### PR TITLE
Expose workflow graph with React visualization

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router-dom": "^7.6.2"
+    "react-router-dom": "^7.6.2",
+    "reactflow": "^11.11.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/client/src/components/WorkflowGraph.tsx
+++ b/client/src/components/WorkflowGraph.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import ReactFlow, { Background, Controls, Edge, Node } from 'reactflow';
+import 'reactflow/dist/style.css';
+
+interface GraphData {
+  nodes?: { name: string }[];
+  edges?: { source: string; target: string }[];
+}
+
+interface Props {
+  data?: GraphData;
+  active?: string | null;
+}
+
+export default function WorkflowGraph({ data, active }: Props) {
+  const nodes: Node[] = (data?.nodes || []).map((n, idx) => ({
+    id: n.name,
+    data: { label: n.name },
+    position: { x: 50, y: idx * 80 },
+    className: active === n.name ? 'bg-green-200' : ''
+  }));
+
+  const edges: Edge[] = (data?.edges || []).map(e => ({
+    id: `${e.source}-${e.target}`,
+    source: e.source,
+    target: e.target
+  }));
+
+  return (
+    <div style={{ height: 400 }}>
+      <ReactFlow nodes={nodes} edges={edges} fitView>
+        <Background />
+        <Controls />
+      </ReactFlow>
+    </div>
+  );
+}

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -2,16 +2,23 @@ import { useState, useEffect } from 'react';
 import GoalInput from '../components/GoalInput';
 import OutputPanel from '../components/OutputPanel';
 import Loader from '../components/Loader';
+import WorkflowGraph from '../components/WorkflowGraph';
 
 export default function Dashboard() {
   const [output, setOutput] = useState('');
   const [progress, setProgress] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+  const [graph, setGraph] = useState<any | null>(null);
+  const [activeTask, setActiveTask] = useState<string | null>(null);
 
   useEffect(() => {
     const ws = new WebSocket('ws://localhost:8000/ws');
-    ws.onmessage = ev => setProgress(prev => [...prev, ev.data]);
+    ws.onmessage = ev => {
+      setProgress(prev => [...prev, ev.data]);
+      const match = /Task:\s*([^\n(]+)/.exec(ev.data);
+      if (match) setActiveTask(match[1].trim());
+    };
     return () => ws.close();
   }, []);
 
@@ -28,6 +35,7 @@ export default function Dashboard() {
       if (!res.ok) throw new Error(`Status ${res.status}`);
       const data = await res.json();
       setOutput(data.output);
+      setGraph(data.graph);
     } catch (err: any) {
       setError(err.message);
     } finally {
@@ -39,6 +47,7 @@ export default function Dashboard() {
     <div style={{ padding: '1rem' }}>
       <h1>EvoAgentX</h1>
       <GoalInput onRun={run} loading={loading} />
+      {graph && <WorkflowGraph data={graph} active={activeTask} />}
       <OutputPanel output={output} progress={progress} />
       {loading && <Loader />}
       {error && <p className="text-red-600 mt-2">{error}</p>}

--- a/evoagentx/core/runner.py
+++ b/evoagentx/core/runner.py
@@ -10,7 +10,10 @@ from dotenv import load_dotenv
 load_dotenv()
 
 
-async def run_workflow_async(goal: str, progress_cb=None) -> str:
+from typing import Tuple, Union
+
+
+async def run_workflow_async(goal: str, progress_cb=None, return_graph: bool = False) -> Union[str, Tuple[str, dict]]:
     """
     Run EvoAgentX workflow asynchronously.
     Raises ValueError if goal too short (handled by caller).
@@ -56,5 +59,7 @@ async def run_workflow_async(goal: str, progress_cb=None) -> str:
     result = await workflow.async_execute(context)
     if progress_cb:
         await progress_cb("Workflow completed")
+    if return_graph:
+        return result, workflow_graph.get_config()
     return result
 

--- a/server/api/run.py
+++ b/server/api/run.py
@@ -8,7 +8,9 @@ router = APIRouter()
 @router.post("/run", response_model=RunResponse)
 async def run(request: RunRequest):
     try:
-        output = await run_workflow_async(request.goal, progress_cb=manager.broadcast)
+        output, graph = await run_workflow_async(
+            request.goal, progress_cb=manager.broadcast, return_graph=True
+        )
     except ValueError as e:
         # < 10 characters or other validation errors
         raise HTTPException(status_code=400, detail=str(e))
@@ -16,4 +18,4 @@ async def run(request: RunRequest):
         # unexpected agent errors
         raise HTTPException(status_code=500, detail="EvoAgent failed") from e
 
-    return RunResponse(goal=request.goal, output=output)
+    return RunResponse(goal=request.goal, output=output, graph=graph)

--- a/server/models/schemas.py
+++ b/server/models/schemas.py
@@ -9,6 +9,7 @@ class RunRequest(BaseModel):
 class RunResponse(BaseModel):
     goal: str
     output: str
+    graph: dict | None = None
 
 
 class EventBase(BaseModel):


### PR DESCRIPTION
## Summary
- add `reactflow` dependency for graph rendering
- extend backend runner to optionally return workflow graph
- expose graph via `/run` endpoint and new schema
- show workflow graph in dashboard with progress highlighting

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851392068e8832694f591e0d81c2935