### PR TITLE
Implement Zustand store for run data

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -13,7 +13,8 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.2",
-    "reactflow": "^11.11.4"
+    "reactflow": "^11.11.4",
+    "zustand": "^4.5.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/client/src/components/OutputPanel.tsx
+++ b/client/src/components/OutputPanel.tsx
@@ -1,16 +1,11 @@
-import type { FC } from 'react';
+import { useRunStore } from '../store/useRunStore';
 
-interface Props {
-  output: string;
-  progress: string[];
-}
-const OutputPanel: FC<Props> = ({ output, progress }) => {
+export default function OutputPanel() {
+  const { output, progress } = useRunStore();
   const text = [...progress, output].filter(Boolean).join('\n');
   return (
     <div className="mt-6 rounded-xl border p-4 bg-gray-50 whitespace-pre-line">
       {text || <span className="text-gray-400">No output yet.</span>}
     </div>
   );
-};
-
-export default OutputPanel;
+}

--- a/client/src/components/WorkflowGraph.tsx
+++ b/client/src/components/WorkflowGraph.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactFlow, { Background, Controls, Edge, Node } from 'reactflow';
+import { useRunStore } from '../store/useRunStore';
 import 'reactflow/dist/style.css';
 
 interface GraphData {
@@ -7,12 +8,8 @@ interface GraphData {
   edges?: { source: string; target: string }[];
 }
 
-interface Props {
-  data?: GraphData;
-  active?: string | null;
-}
-
-export default function WorkflowGraph({ data, active }: Props) {
+export default function WorkflowGraph() {
+  const { graph: data, activeTask: active } = useRunStore();
   const nodes: Node[] = (data?.nodes || []).map((n, idx) => ({
     id: n.name,
     data: { label: n.name },

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -1,31 +1,41 @@
-import { useState, useEffect } from 'react';
+import { useEffect } from 'react';
 import GoalInput from '../components/GoalInput';
 import OutputPanel from '../components/OutputPanel';
 import Loader from '../components/Loader';
 import WorkflowGraph from '../components/WorkflowGraph';
+import { useRunStore } from '../store/useRunStore';
 
 export default function Dashboard() {
-  const [output, setOutput] = useState('');
-  const [progress, setProgress] = useState<string[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState('');
-  const [graph, setGraph] = useState<any | null>(null);
-  const [activeTask, setActiveTask] = useState<string | null>(null);
+  const {
+    loading,
+    error,
+    graph,
+    activeTask,
+    setLoading,
+    setError,
+    addProgress,
+    setOutput,
+    setGraph,
+    setActiveTask,
+    setTokenUsage,
+    reset
+  } = useRunStore();
 
   useEffect(() => {
     const ws = new WebSocket('ws://localhost:8000/ws');
     ws.onmessage = ev => {
-      setProgress(prev => [...prev, ev.data]);
+      addProgress(ev.data);
       const match = /Task:\s*([^\n(]+)/.exec(ev.data);
       if (match) setActiveTask(match[1].trim());
     };
     return () => ws.close();
-  }, []);
+  }, [addProgress, setActiveTask]);
 
   const run = async (goal: string) => {
     setLoading(true);
     setError('');
-    setProgress([]);
+    reset();
+    setLoading(true);
     try {
       const res = await fetch('http://localhost:8000/run', {
         method: 'POST',
@@ -36,6 +46,7 @@ export default function Dashboard() {
       const data = await res.json();
       setOutput(data.output);
       setGraph(data.graph);
+      if (data.token_usage) setTokenUsage(data.token_usage);
     } catch (err: any) {
       setError(err.message);
     } finally {
@@ -47,8 +58,8 @@ export default function Dashboard() {
     <div style={{ padding: '1rem' }}>
       <h1>EvoAgentX</h1>
       <GoalInput onRun={run} loading={loading} />
-      {graph && <WorkflowGraph data={graph} active={activeTask} />}
-      <OutputPanel output={output} progress={progress} />
+      {graph && <WorkflowGraph />}
+      <OutputPanel />
       {loading && <Loader />}
       {error && <p className="text-red-600 mt-2">{error}</p>}
     </div>

--- a/client/src/store/useRunStore.ts
+++ b/client/src/store/useRunStore.ts
@@ -1,0 +1,51 @@
+import { create } from 'zustand';
+
+export interface GraphData {
+  nodes?: { name: string }[];
+  edges?: { source: string; target: string }[];
+}
+
+interface RunState {
+  output: string;
+  progress: string[];
+  loading: boolean;
+  error: string;
+  graph: GraphData | null;
+  activeTask: string | null;
+  tokenUsage: number;
+  setLoading: (loading: boolean) => void;
+  setError: (error: string) => void;
+  addProgress: (msg: string) => void;
+  setOutput: (output: string) => void;
+  setGraph: (graph: GraphData | null) => void;
+  setActiveTask: (task: string | null) => void;
+  setTokenUsage: (usage: number) => void;
+  reset: () => void;
+}
+
+export const useRunStore = create<RunState>(set => ({
+  output: '',
+  progress: [],
+  loading: false,
+  error: '',
+  graph: null,
+  activeTask: null,
+  tokenUsage: 0,
+  setLoading: loading => set({ loading }),
+  setError: error => set({ error }),
+  addProgress: msg => set(state => ({ progress: [...state.progress, msg] })),
+  setOutput: output => set({ output }),
+  setGraph: graph => set({ graph }),
+  setActiveTask: task => set({ activeTask: task }),
+  setTokenUsage: usage => set({ tokenUsage: usage }),
+  reset: () =>
+    set({
+      output: '',
+      progress: [],
+      loading: false,
+      error: '',
+      graph: null,
+      activeTask: null,
+      tokenUsage: 0
+    })
+}));


### PR DESCRIPTION
## Summary
- add Zustand dependency for the React client
- create `useRunStore` to share run state, output, token usage and workflow info
- refactor Dashboard and components to use the new store

## Testing
- `pip install -e .[dev]`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68513b149cac8326a55576bc02cffb03