### PR TITLE
Fix input insertion in PromptTemplate

### DIFF
--- a/evoagentx/prompts/template.py
+++ b/evoagentx/prompts/template.py
@@ -117,13 +117,17 @@ class PromptTemplate(BaseModule):
 
         return text
     
-    def check_required_inputs(self, inputs_format: Type[LLMOutputParser], values: dict):
-        if inputs_format is None: 
-            return 
+    def check_required_inputs(self, inputs_format: Type[LLMOutputParser], values: dict, missing_field_value: str = ""):
+        if inputs_format is None:
+            return
         required_inputs = self.get_required_inputs_or_outputs(inputs_format)
         missing_required_inputs = [field for field in required_inputs if field not in values]
         if missing_required_inputs:
-            logger.warning(f"Missing required inputs (without default values) for `{inputs_format.__name__}`: {missing_required_inputs}, will set them to empty strings.")
+            logger.warning(
+                f"Missing required inputs (without default values) for `{inputs_format.__name__}`: {missing_required_inputs}, will set them to empty strings."
+            )
+            for field in missing_required_inputs:
+                values[field] = missing_field_value
     
     def render_input_example(self, inputs_format: Type[LLMOutputParser], values: dict, missing_field_value: str = "") -> str:
         if inputs_format is None and values is None:

--- a/tests/test_prompt_template_tools.py
+++ b/tests/test_prompt_template_tools.py
@@ -1,6 +1,7 @@
 import pytest
 from evoagentx.prompts.template import PromptTemplate
 from evoagentx.tools.tool import Tool
+from evoagentx.models.base_model import LLMOutputParser
 from typing import List, Dict, Any, Callable
 
 class SimpleTool(Tool):
@@ -44,3 +45,17 @@ def test_render_tools_mismatch():
     tmpl = PromptTemplate(instruction="instr", tools=[BadTool()])
     with pytest.raises(ValueError):
         tmpl.render_tools()
+
+
+class SimpleInput(LLMOutputParser):
+    required_field: str
+    optional_field: str = "opt"
+
+
+def test_missing_required_inputs_are_added():
+    tmpl = PromptTemplate(instruction="instr")
+    values = {}
+    tmpl.check_required_inputs(SimpleInput, values)
+    assert "required_field" in values
+    assert values["required_field"] == ""
+    assert "optional_field" not in values


### PR DESCRIPTION
## Summary
- insert missing required inputs into PromptTemplate values
- add regression test verifying required fields are populated

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851c0dac204832694ec7de64a2a85bb