### PR TITLE
Update vite config and docs

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -11,5 +11,6 @@ export default defineConfig({
   plugins: [react()],
   server: {
     port: 5173,
+    strictPort: true,
   },
 });

--- a/docs/development.md
+++ b/docs/development.md
@@ -97,7 +97,7 @@ uvicorn server.main:sio_app --reload
 ```bash
 cd client
 npm install # or pnpm install
-npm run dev
+npm run dev -- --host 0.0.0.0
 ```
 
 - The frontend will be available at `http://localhost:5173` by default (see `vite.config.ts`).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -95,7 +95,7 @@ uvicorn server.main:sio_app --reload
 ```bash
 cd client
 npm install # or pnpm install
-npm run dev
+npm run dev -- --host 0.0.0.0
 ```
 
 - The frontend will be available at `http://localhost:5173` by default (see `vite.config.ts`).


### PR DESCRIPTION
## Summary
- keep the client dev server on the same port using strictPort
- document how to expose the frontend externally

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685926a9f6948326b4f5f554c40cf424