### PR TITLE
Allow remote access for dev server

### DIFF
--- a/start-dev.sh
+++ b/start-dev.sh
@@ -44,8 +44,8 @@ for pkg in "${REQUIRED_PKGS[@]}"; do
  done
 
 # Print status
-echo "Starting frontend (Vite dev server)..."
-npm run dev &
+echo "Starting frontend (Vite dev server, accessible on all interfaces)..."
+npm run dev -- --host 0.0.0.0 &
 FRONTEND_PID=$!
 
 # 6. Open dashboard in default browser (macOS only)


### PR DESCRIPTION
## Summary
- allow vite dev server to listen on all interfaces in `start-dev.sh`

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68592a278d048326947264015d1d73dc