### PR TITLE
Allow backend access from network

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -87,10 +87,11 @@ To run both the FastAPI backend (with Socket.IO support) and the React frontend:
 1. **Start the backend with Socket.IO:**
 
 ```bash
-uvicorn server.main:sio_app --reload
+uvicorn server.main:sio_app --host 0.0.0.0 --reload
 ```
 
-- This exposes both REST API and Socket.IO endpoints on `http://localhost:8000`.
+- This exposes both REST API and Socket.IO endpoints on `http://localhost:8000` 
+  and makes the backend reachable from other devices on your network.
 
 2. **Start the frontend (Vite):**
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -85,10 +85,11 @@ To run both the FastAPI backend (with Socket.IO support) and the React frontend:
 1. **Start the backend with Socket.IO:**
 
 ```bash
-uvicorn server.main:sio_app --reload
+uvicorn server.main:sio_app --host 0.0.0.0 --reload
 ```
 
-- This exposes both REST API and Socket.IO endpoints on `http://localhost:8000`.
+- This exposes both REST API and Socket.IO endpoints on `http://localhost:8000` 
+  and makes the backend reachable from other devices on your network.
 
 2. **Start the frontend (Vite):**
 

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -21,7 +21,7 @@ if lsof -i:8000 -t >/dev/null; then
 fi
 
 # 4. Start backend
-(uvicorn server.main:sio_app --reload &)
+(uvicorn server.main:sio_app --host 0.0.0.0 --reload &)
 BACKEND_PID=$!
 echo "Started backend (PID $BACKEND_PID) on http://localhost:8000"
 


### PR DESCRIPTION
## Summary
- expose backend on all interfaces in `start-dev.sh`
- document backend `--host 0.0.0.0` usage for development and installation guides

## Testing
- `pip install -e .[dev]`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'datasets')*

------
https://chatgpt.com/codex/tasks/task_e_68592dba31b08326b1b3987d9b6b6d55