### PR TITLE
Add coverage for factory dict configs

### DIFF
--- a/tests/test_factory_extended.py
+++ b/tests/test_factory_extended.py
@@ -1,0 +1,35 @@
+import pytest
+
+from evoagentx.utils import factory
+
+
+
+def test_dbstorefactory_create_with_dict(monkeypatch):
+    class Dummy:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+    monkeypatch.setattr(factory, "load_class", lambda path: Dummy)
+    cfg = {"path": ":memory:"}
+    obj = factory.DBStoreFactory.create("sqlite", cfg)
+    assert isinstance(obj, Dummy)
+    assert obj.kwargs["path"] == ":memory:"
+
+
+def test_vectorstorefactory_create_with_dict(monkeypatch):
+    class Dummy:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+    monkeypatch.setattr(factory, "load_class", lambda path: Dummy)
+    obj = factory.VectorStoreFactory.create({"provider": "qdrant", "foo": "bar"})
+    assert isinstance(obj, Dummy)
+    assert obj.kwargs["foo"] == "bar"
+
+
+def test_graphstorefactory_create_with_dict(monkeypatch):
+    class Dummy:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+    monkeypatch.setattr(factory, "load_class", lambda path: Dummy)
+    obj = factory.GraphStoreFactory.create({"provider": "neo4j", "uri": "bolt"})
+    assert isinstance(obj, Dummy)
+    assert obj.kwargs["uri"] == "bolt"


### PR DESCRIPTION
## Summary
- cover factory `create` methods using dictionary config objects

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68593837690483268e4ea6775b4cb620