### PR TITLE
Add ALLOWED_ORIGINS support

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -114,4 +114,5 @@ bash start-dev.sh
 **Note:**
 - The frontend (`localhost:5173`) proxies API and Socket.IO requests to the backend (`localhost:8000`).
 - Make sure you always run the backend as `sio_app` for Socket.IO support.
+- Set `ALLOWED_ORIGINS` to specify which origins may access the backend. Provide a comma-separated list, e.g. `ALLOWED_ORIGINS=http://localhost:5173,https://example.com`. If unset, it defaults to `http://localhost:5173`.
 

--- a/server/main.py
+++ b/server/main.py
@@ -1,18 +1,22 @@
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
+import os
 import socketio
 
 from .api.run import router as run_router
 from .api.calendar import calendar_router
 from .core.websocket_manager import manager
 
+sio_allowed_origins = os.getenv("ALLOWED_ORIGINS", "http://localhost:5173")
+allowed_origins = [origin.strip() for origin in sio_allowed_origins.split(',') if origin.strip()]
+
 app = FastAPI()
-sio = socketio.AsyncServer(async_mode='asgi', cors_allowed_origins=['http://localhost:5173'])
+sio = socketio.AsyncServer(async_mode='asgi', cors_allowed_origins=allowed_origins)
 sio_app = socketio.ASGIApp(sio, app)
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5173"],
+    allow_origins=allowed_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary
- read allowed origins from `ALLOWED_ORIGINS` env var in FastAPI server
- document the new variable in the installation guide

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685938e5e6ec8326a62c3dcde702a04f