### PR TITLE
Improve fetch error handling in metrics charts

### DIFF
--- a/client/src/components/MetricsChart.tsx
+++ b/client/src/components/MetricsChart.tsx
@@ -6,23 +6,27 @@ const MetricsChart: React.FC = () => {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    // Fetch the most recent execution
-    fetch('/api/executions?limit=1')
-      .then(res => res.json())
-      .then(executions => {
+    const load = async () => {
+      try {
+        console.log('Fetching:', '/api/executions?limit=1');
+        const res = await fetch('/api/executions?limit=1');
+        if (!res.ok) throw new Error(`Server returned ${res.status}`);
+        const executions = await res.json();
         if (executions && executions.length > 0) {
           const exec = executions[0];
-          // Extract metrics from the results field
           const results = exec.results || {};
-          // Assume metrics are key-value pairs in results
           const chartData = Object.entries(results)
             .filter(([_, v]) => typeof v === 'number')
             .map(([metric, value]) => ({ metric, value }));
           setData(chartData);
         }
+      } catch (err) {
+        console.error('Failed to fetch metrics', err);
+      } finally {
         setLoading(false);
-      })
-      .catch(() => setLoading(false));
+      }
+    };
+    void load();
   }, []);
 
   if (loading) return <div>Loading...</div>;

--- a/client/src/components/TokenBurnDownChart.tsx
+++ b/client/src/components/TokenBurnDownChart.tsx
@@ -7,16 +7,18 @@ const TokenBurnDownChart: React.FC = () => {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    // Fetch the most recent execution
-    fetch('/api/executions?limit=1')
-      .then(res => res.json())
-      .then(async executions => {
+    const load = async () => {
+      try {
+        console.log('Fetching:', '/api/executions?limit=1');
+        const res = await fetch('/api/executions?limit=1');
+        if (!res.ok) throw new Error(`Server returned ${res.status}`);
+        const executions = await res.json();
         if (executions && executions.length > 0) {
           const exec = executions[0];
-          // Fetch details for the most recent execution
+          console.log('Fetching:', `/api/executions/${exec.id}`);
           const execRes = await fetch(`/api/executions/${exec.id}`);
+          if (!execRes.ok) throw new Error(`Server returned ${execRes.status}`);
           const execDetails = await execRes.json();
-          // Transform step_results into chart data
           const stepResults = execDetails.step_results || {};
           const chartData = Object.entries(stepResults).map(([step, details]: any) => ({
             step,
@@ -24,9 +26,13 @@ const TokenBurnDownChart: React.FC = () => {
           }));
           setData(chartData);
         }
+      } catch (err) {
+        console.error('Failed to fetch token data', err);
+      } finally {
         setLoading(false);
-      })
-      .catch(() => setLoading(false));
+      }
+    };
+    void load();
   }, []);
 
   if (loading) return <div>Loading...</div>;


### PR DESCRIPTION
## Summary
- add explicit error handling and logging in `MetricsChart` and `TokenBurnDownChart`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68593bd6dbfc832689bcb83007ca0447